### PR TITLE
Update DO kubernetes cluster version to 1.22.11

### DIFF
--- a/terraform/modules/digital-ocean/cluster.tf
+++ b/terraform/modules/digital-ocean/cluster.tf
@@ -11,9 +11,9 @@ variable "do_cluster_region" {
 
 variable "do_cluster_version" {
   # list is available at https://slugs.do-api.dev/ on "Kubernetes Versions"
-  # default is - 1.22.8
+  # default is - 1.22.11
   description = "The slug identifier for the version of Kubernetes used for the cluster"
-  default     = "1.22.8-do.1"
+  default     = "1.22.11-do.0"
 }
 
 variable "do_cluster_node_size" {


### PR DESCRIPTION
## Description
- Kubernetes cluster version is outdated and not applicable anymore. Changed from `1.22.8` to `1.22.11`

## Database schema changes
- NA

## Tests
### Automated test cases added
- NA

### Manual test cases run
- NA