### PR TITLE
PT-45: Add support for videos / screenshots for failing test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ terraform/terraform.tfstate
 terraform/.terraform.tfstate.lock.info
 terraform/terraform.tfstate.backup
 terraform/*.tfvars
+
+#cypress
+cypress/videos
+cypress/screenshots

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,16 +8,14 @@ export default defineConfig({
     setupNodeEvents(on) {
       on('task', {
         'scenario:cleanup': async (scenario: string) => {
-          if (scenarios[scenario] === undefined)
-            throw new Error('Undefined Scenario');
+          if (scenarios[scenario] === undefined) throw new Error('Undefined Scenario');
 
           await scenarios[scenario].cleanup();
 
           return null;
         },
         'scenario:setup': async (scenario: string) => {
-          if (scenarios[scenario] === undefined)
-            throw new Error('Undefined Scenario');
+          if (scenarios[scenario] === undefined) throw new Error('Undefined Scenario');
 
           const res = await scenarios[scenario].setup();
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,14 +8,16 @@ export default defineConfig({
     setupNodeEvents(on) {
       on('task', {
         'scenario:cleanup': async (scenario: string) => {
-          if (scenarios[scenario] === undefined) throw new Error('Undefined Scenario');
+          if (scenarios[scenario] === undefined)
+            throw new Error('Undefined Scenario');
 
           await scenarios[scenario].cleanup();
 
           return null;
         },
         'scenario:setup': async (scenario: string) => {
-          if (scenarios[scenario] === undefined) throw new Error('Undefined Scenario');
+          if (scenarios[scenario] === undefined)
+            throw new Error('Undefined Scenario');
 
           const res = await scenarios[scenario].setup();
 
@@ -32,6 +34,4 @@ export default defineConfig({
     // Default is 0
     openMode: 0,
   },
-  screenshotOnRunFailure: false,
-  video: false,
 });


### PR DESCRIPTION
## Description

Added in support for Cypress Screenshots and Videos. Videos will be recorded each run as Cypress has no configuration to limit this to failing runs. But the screenshots are done on failure.

## Database schema changes

## Tests
### Automated test cases added

### Manual test cases run
