### PR TITLE
Fix webpack-dev-server routing issues

### DIFF
--- a/src/apps/frontend/webpack.dev.js
+++ b/src/apps/frontend/webpack.dev.js
@@ -12,11 +12,13 @@ const config = {
   },
   devtool: 'inline-source-map',
   devServer: {
+    historyApiFallback: true,
     hot: true,
     open: true,
     port: 3000,
     proxy: {
       '/api': 'http://localhost:8080',
+      '/assets': 'http://localhost:8080',
     },
   },
 };


### PR DESCRIPTION
## Description
- Fixed issue where reloading a page from another path threw `Cannot get path /` error
- Fixed issue where assets could not be resolved when running webpack dev server

## Database schema changes
- NA

## Tests
### Automated test cases added
- NA

### Manual test cases run
- Should be able to reload and get associated page on frontend
- Should be able to resolve assets when running `webpack-dev-server`
