### PR TITLE
Migrate workflows to v2.8

### DIFF
--- a/.github/workflows/clean_on_delete.yml
+++ b/.github/workflows/clean_on_delete.yml
@@ -6,7 +6,7 @@ jobs:
   clean:
     # only run when deleting a branch
     if: github.event.ref_type == 'branch'
-    uses: jalantechnologies/platform-github/.github/workflows/clean.yml@v2.7
+    uses: jalantechnologies/platform-github/.github/workflows/clean.yml@v2.8
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_dispatch.yml
+++ b/.github/workflows/clean_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   clean:
-    uses: jalantechnologies/platform-github/.github/workflows/clean.yml@v2.7
+    uses: jalantechnologies/platform-github/.github/workflows/clean.yml@v2.8
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   clean:
-    uses: jalantechnologies/platform-github/.github/workflows/clean.yml@v2.7
+    uses: jalantechnologies/platform-github/.github/workflows/clean.yml@v2.8
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_dispatch.yml
+++ b/.github/workflows/preview_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   preview:
-    uses: jalantechnologies/platform-github/.github/workflows/kube.yml@v2.7
+    uses: jalantechnologies/platform-github/.github/workflows/kube.yml@v2.8
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -8,7 +8,7 @@ jobs:
   preview:
     # only run when updating an 'Open' PR
     if: github.event.pull_request.state == 'open'
-    uses: jalantechnologies/platform-github/.github/workflows/kube.yml@v2.7
+    uses: jalantechnologies/platform-github/.github/workflows/kube.yml@v2.8
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -21,9 +21,9 @@ jobs:
       pull_request_number: ${{ github.event.number }}
       build_args: |
         NODE_CONFIG_ENV=preview
-      docker_registry: docker-registry.platform.jalantechnologies.com
+      docker_registry: ${{ vars.DOCKER_REGISTRY }}
+      docker_username: ${{ vars.DOCKER_USERNAME }}
     secrets:
-      docker_username: ${{ secrets.DOCKER_USERNAME }}
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
       doppler_token: ${{ secrets.DOPPLER_PREVIEW_TOKEN }}
       do_access_token: ${{ secrets.DO_ACCESS_TOKEN }}

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -8,7 +8,7 @@ jobs:
   preview:
     # only run when updating an 'Open' PR
     if: github.event.pull_request.state == 'open'
-    uses: jalantechnologies/platform-github/.github/workflows/kube.yml@v2.8
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -21,8 +21,8 @@ jobs:
       pull_request_number: ${{ github.event.number }}
       build_args: |
         NODE_CONFIG_ENV=preview
+      docker_registry: docker-registry.platform.jalantechnologies.com
     secrets:
-      docker_registry: docker-registry.platform.jalantechnologies.com/boilerplate-mern
       docker_username: ${{ secrets.DOCKER_USERNAME }}
       docker_password: ${{ secrets.DOCKER_PASSWORD }}
       doppler_token: ${{ secrets.DOPPLER_PREVIEW_TOKEN }}

--- a/.github/workflows/production_on_push.yml
+++ b/.github/workflows/production_on_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   production:
-    uses: jalantechnologies/platform-github/.github/workflows/kube.yml@v2.7
+    uses: jalantechnologies/platform-github/.github/workflows/kube.yml@v2.8
     concurrency:
       group: ci-production-${{ github.event.ref }}
       cancel-in-progress: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,15 @@ RUN apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-
 
 # use changes to package.json to force Docker not to use the cache
 # when we change our application's nodejs dependencies:
-COPY package.json package.json
-COPY package-lock.json package-lock.json
+COPY package.json /tmp/package.json
+RUN cd /tmp && npm install
+RUN mkdir -p /opt/app && cp -a /tmp/node_modules /opt/app/
+
+WORKDIR /opt/app
+
 RUN npm install
 
-COPY . .
-
-RUN npm install
+COPY . /opt/app
 
 # build arguments
 ARG NODE_ENV

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This project deploys on Kubernetes via GitHub actions using workflows defined in
 
 **Version:**
 
-This project uses [v2.4](https://github.com/jalantechnologies/platform-github/tree/v2.3)
+This project uses [v2.8](https://github.com/jalantechnologies/platform-github/tree/v2.8)
 
 **Features:**
 

--- a/cypress/e2e/login.spec.cy.ts
+++ b/cypress/e2e/login.spec.cy.ts
@@ -13,8 +13,10 @@ describe('Login', () => {
   });
 
   it('should allow login', () => {
-    cy.get('#username').clear().type(credentials.username);
-    cy.get('#password').clear().type(credentials.password);
+    cy.get('#username').clear();
+    cy.get('#username').type(credentials.username);
+    cy.get('#password').clear();
+    cy.get('#password').type(credentials.password);
     cy.get('button').click();
 
     cy.get('#success').should('be.visible').should('have.text', 'SUCCESS!');
@@ -22,8 +24,10 @@ describe('Login', () => {
 
   it('should not allow login for removed credentials', () => {
     cy.task('scenario:cleanup', 'login');
-    cy.get('#username').clear().type(credentials.username);
-    cy.get('#password').clear().type(credentials.password);
+    cy.get('#username').clear();
+    cy.get('#username').type(credentials.username);
+    cy.get('#password').clear();
+    cy.get('#password').type(credentials.password);
     cy.get('button').click();
 
     cy.get('#error').should('be.visible').should('have.text', 'ERROR!');

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -16,5 +16,6 @@ services:
 
   db:
     image: mongo:5.0
+    command: mongod --quiet --logpath /dev/null
     ports:
       - '27017:27017'

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,6 +382,21 @@
       "integrity": "sha512-8YXBE2ZcU/pImVOHX7MWrSR/X5up7t6rPWZlk34RwZEcdr3ua6X+32pSd6XuOQRN+vbuvYNfA6iey8NbrjuMFQ==",
       "dev": true
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -698,6 +713,27 @@
         "@sendgrid/client": "^7.7.0",
         "@sendgrid/helpers": "^7.7.0"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -6751,6 +6787,19 @@
         }
       }
     },
+    "joi": {
+      "version": "17.9.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
+      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12371,6 +12420,57 @@
       "dev": true,
       "requires": {
         "vfile-message": "^3.0.0"
+      }
+    },
+    "wait-on": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
+      "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.27.2",
+        "joi": "^17.7.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.7",
+        "rxjs": "^7.8.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "minimist": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+          "dev": true
+        },
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "watchpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4701,9 +4701,9 @@
       }
     },
     "eslint-plugin-cypress": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
-      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.3.tgz",
+      "integrity": "sha512-nAPjZE5WopCsgJwl3vHm5iafpV+ZRO76Z9hMyRygWhmg5ODXDPd+9MaPl7kdJ2azj+sO87H3P1PRnggIrz848g==",
       "dev": true,
       "requires": {
         "globals": "^11.12.0"

--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
     "node": "14.17.3"
   },
   "scripts": {
-    "build": "cross-env NODE_ENV=production concurrently npm:build:* --kill-others-on-fail",
+    "build": "cross-env NODE_ENV=production concurrently --kill-others-on-fail npm:build:*",
     "build:assets": "cpx \"src/assets/**/*.*\" dist/assets",
     "build:backend": "tsc -p src/apps/backend/tsconfig.json --outDir dist",
     "build:frontend": "webpack --output-path dist/public --config src/apps/frontend/webpack.prod.js",
     "test": "cross-env NODE_ENV=production NODE_CONFIG_ENV=testing mocha --exit -r ts-node/register --project src/apps/backend/tsconfig.json test/**/*.spec.ts",
-    "test:e2e": "cross-env NODE_ENV=production NODE_CONFIG_ENV=e2e concurrently -s first -k --kill-others-on-fail \"npm start\" \"sleep 2 && cypress run\"",
+    "test:e2e": "cross-env NODE_ENV=production NODE_CONFIG_ENV=e2e concurrently --success first --kill-others --kill-others-on-fail \"wait-on tcp:8080 && cypress run\" \"npm start\"",
     "lint": "eslint .",
     "lint:md": "remark .",
     "lint:fix": "eslint --fix .",
     "start": "node dist/bin/server.js",
-    "serve": "cross-env NODE_ENV=development concurrently npm:serve:* --kill-others-on-fail",
+    "serve": "cross-env NODE_ENV=development concurrently --kill-others-on-fail npm:serve:*",
     "serve:assets": "cpx \"src/assets/**/*.*\" dist/assets --watch",
     "serve:backend": "tsc-watch -p src/apps/backend/tsconfig.json --outDir dist --onsuccess \"node dist/bin/server.js\" --noClear",
     "serve:frontend": "webpack serve --output-path dist/public --config src/apps/frontend/webpack.dev.js --hot --progress"
@@ -98,6 +98,7 @@
     "ts-mocha": "^9.0.2",
     "tsc-watch": "^5.0.3",
     "typescript": "^4.4.4",
+    "wait-on": "^7.0.1",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:backend": "tsc -p src/apps/backend/tsconfig.json --outDir dist",
     "build:frontend": "webpack --output-path dist/public --config src/apps/frontend/webpack.prod.js",
     "test": "cross-env NODE_ENV=production NODE_CONFIG_ENV=testing mocha --exit -r ts-node/register --project src/apps/backend/tsconfig.json test/**/*.spec.ts",
-    "test:e2e": "cross-env NODE_ENV=production NODE_CONFIG_ENV=e2e npm run build && concurrently -s first -k --kill-others-on-fail \"npm start\" \"sleep 2 && cypress run\"",
+    "test:e2e": "cross-env NODE_ENV=production NODE_CONFIG_ENV=e2e concurrently -s first -k --kill-others-on-fail \"npm start\" \"sleep 2 && cypress run\"",
     "lint": "eslint .",
     "lint:md": "remark .",
     "lint:fix": "eslint --fix .",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^14.0.1",
-    "eslint-plugin-cypress": "^2.12.1",
+    "eslint-plugin-cypress": "^2.13.3",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.25.2",
     "forever": "^4.0.3",


### PR DESCRIPTION
## Description
- [fix] Fixed caching issues in `Dockerfile`
- [fix] Removed build process when running e2e tests. When running in CIs, build is already present and there's no need to rebuild.
- [fix] E2E now uses `wait-on` to wait for server to start instead of sleeping arbitrary
- [fix] Upgraded `eslint-plugin-cypress` package which were causing cypress lint checks to pass locally but fail on CI.
- [chore] Removed mongodb logs from e2e compose to reduce noise
- [chore] This migrates workflows to v2.8

## Database schema changes
- NA

## Tests
### Automated test cases added
- NA

### Manual test cases run
- NA
