### PR TITLE
Bump CI version to v1.3

### DIFF
--- a/.github/workflows/clean_on_delete.yml
+++ b/.github/workflows/clean_on_delete.yml
@@ -6,7 +6,7 @@ jobs:
   clean:
     # only run when deleting a branch
     if: github.event.ref_type == 'branch'
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_delete.yml
+++ b/.github/workflows/clean_on_delete.yml
@@ -6,7 +6,7 @@ jobs:
   clean:
     # only run when deleting a branch
     if: github.event.ref_type == 'branch'
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.3
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_delete.yml
+++ b/.github/workflows/clean_on_delete.yml
@@ -6,7 +6,7 @@ jobs:
   clean:
     # only run when deleting a branch
     if: github.event.ref_type == 'branch'
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2.1
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_dispatch.yml
+++ b/.github/workflows/clean_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_dispatch.yml
+++ b/.github/workflows/clean_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2.1
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_dispatch.yml
+++ b/.github/workflows/clean_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.3
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2.1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.3
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2.1
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   clean:
-    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1
+    uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v1.2
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_dispatch.yml
+++ b/.github/workflows/preview_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   preview:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2.1
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_dispatch.yml
+++ b/.github/workflows/preview_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   preview:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.3
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_dispatch.yml
+++ b/.github/workflows/preview_on_dispatch.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   preview:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2
     concurrency:
       group: ci-preview-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -8,7 +8,7 @@ jobs:
   preview:
     # only run when updating an 'Open' PR
     if: github.event.pull_request.state == 'open'
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.3
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -8,7 +8,7 @@ jobs:
   preview:
     # only run when updating an 'Open' PR
     if: github.event.pull_request.state == 'open'
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/preview_on_pr_update.yml
+++ b/.github/workflows/preview_on_pr_update.yml
@@ -8,7 +8,7 @@ jobs:
   preview:
     # only run when updating an 'Open' PR
     if: github.event.pull_request.state == 'open'
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2.1
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}
       cancel-in-progress: true

--- a/.github/workflows/production_on_push.yml
+++ b/.github/workflows/production_on_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   production:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2.1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.3
     concurrency:
       group: ci-production-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/production_on_push.yml
+++ b/.github/workflows/production_on_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   production:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2
     concurrency:
       group: ci-production-${{ github.event.ref }}
       cancel-in-progress: true

--- a/.github/workflows/production_on_push.yml
+++ b/.github/workflows/production_on_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   production:
-    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2
+    uses: jalantechnologies/github-ci/.github/workflows/ci.yml@v1.2.1
     concurrency:
       group: ci-production-${{ github.event.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
## Description
- This bumps CI version to [v1.2](https://github.com/jalantechnologies/github-ci/releases/tag/v1.2)

## Database schema changes
- NA

## Tests
### Automated test cases added
- NA

### Manual test cases run
- NA
