### PR TITLE
Prioritise the production deployment

### DIFF
--- a/lib/kube/production/deployment-pdb.yaml
+++ b/lib/kube/production/deployment-pdb.yaml
@@ -1,9 +1,0 @@
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: $KUBE_APP-pdb
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: $KUBE_APP

--- a/lib/kube/production/deployment.yaml
+++ b/lib/kube/production/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000
+globalDefault: false
+description: "This priority class is for production deployments"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: $KUBE_APP-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: $KUBE_APP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $KUBE_APP-deployment
+  namespace: $KUBE_NS
+  labels:
+    app: $KUBE_APP
+    version: $GITHUB_SHA
+  annotations:
+    secrets.doppler.com/reload: 'true'
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: $KUBE_APP
+  template:
+    metadata:
+      labels:
+        app: $KUBE_APP
+    spec:
+      priorityClassName: high-priority
+      imagePullSecrets:
+        - name: regcred
+      containers:
+        - name: $KUBE_APP
+          image: $KUBE_DEPLOYMENT_IMAGE
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: '256Mi'
+            limits:
+              memory: '512Mi'
+          ports:
+            - containerPort: 8080
+          env:
+            - name: NODE_ENV
+              value: 'production'
+            - name: NODE_CONFIG_ENV
+              value: $KUBE_ENV
+            - name: WEB_APP_HOST
+              value: $KUBE_INGRESS_HOSTNAME
+            - name: PAPERTRAIL_PROGRAM
+              value: $KUBE_APP
+          envFrom:
+            - secretRef:
+                name: $DOPPLER_MANAGED_SECRET_NAME
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30


### PR DESCRIPTION
## Description
We faced a problem in the production where the website goes down if we have large number of open PR’s
This PR includes 2 main changes
- Gives high priority to production deployment
- Increases the replicas to 2 for production deployment

## Database schema changes
- M/A

## Tests
### Automated test cases added
- N/A

### Manual test cases run
- N/A
