### PR TITLE
Feat: Add default OTP for account creation

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -1,6 +1,8 @@
 accounts:
   passwordResetEmailEnabled: true
 
+defaultOTP: '1111'
+
 enableSMS: true
 
 logger:


### PR DESCRIPTION
## Description
_To temporarily enable account login/creation using default OTP in production._

## Database schema changes
NA

## Tests
### Automated test cases added
NA

### Manual test cases run
NA
