### PR TITLE
Fix: Types conflicting issue with mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:assets": "cpx \"src/assets/**/*.*\" dist/assets",
     "build:backend": "tsc -p src/apps/backend/tsconfig.json --outDir dist",
     "build:frontend": "webpack --output-path dist/public --config src/apps/frontend/webpack.prod.js",
-    "test": "cross-env NODE_ENV=production NODE_CONFIG_ENV=testing mocha --exit -r ts-node/register --project src/apps/backend/tsconfig.json test/**/*.spec.ts",
+    "test": "cross-env NODE_ENV=production NODE_CONFIG_ENV=testing mocha --exit -r ts-node/register --project tsconfig.mocha.json test/**/*.spec.ts",
     "test:e2e": "cross-env NODE_ENV=production NODE_CONFIG_ENV=e2e concurrently --success first --kill-others --kill-others-on-fail \"wait-on tcp:8080 && cypress run\" \"npm start\"",
     "lint": "eslint .",
     "lint:md": "remark .",

--- a/src/apps/backend/tsconfig.json
+++ b/src/apps/backend/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../../tsconfig.json"
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }

--- a/tsconfig.mocha.json
+++ b/tsconfig.mocha.json
@@ -5,4 +5,3 @@
     },
     "include": ["test/**/*.spec.ts"]
   }
-  

--- a/tsconfig.mocha.json
+++ b/tsconfig.mocha.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "types": ["node", "mocha"]
+    },
+    "include": ["test/**/*.spec.ts"]
+  }
+  


### PR DESCRIPTION
## Description
_This PR introduces important updates to TypeScript configurations and npm scripts to better support backend and testing workflows._

## Changes

### TypeScript Configuration Updates:

- Backend Configuration: Updated src/apps/backend/tsconfig.json to include "types": ["node"] in the compilerOptions. This ensures TypeScript correctly recognizes Node.js types in the backend.
- Mocha Configuration: Added a new tsconfig.mocha.json at the root of the project to handle Mocha testing with appropriate type definitions. This configuration extends the base tsconfig.json and includes mocha types for proper test handling.

These changes address encountered issues with TypeScript configurations resolving conflicts between global type definitions for testing libraries.

### Additional Notes:
The tsconfig.mocha.json ensures that Mocha tests have access to the necessary type definitions while avoiding conflicts with other TypeScript settings.
Backend TypeScript settings now properly recognize Node.js types, improving type safety and compatibility.

For Global types conflicting issue this is the only/best solution as mentioned [here](https://github.com/microsoft/TypeScript/issues/17663).

## Database schema changes
NA

## Tests
### Automated test cases added
NA

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
NA
