### PR TITLE
feat: Add support for default phone number and otp

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -6,6 +6,10 @@ mailer:
   defaultEmailName: 'DEFAULT_EMAIL_NAME'
   forgetPasswordMailTemplateId: 'FORGOT_PASSWORD_MAIL_TEMPLATE_ID'
 
+otp:
+  defaultOTP: 'DEFAULT_OTP'
+  defaultPhoneNumber: 'DEFAULT_PHONE_NUMBER'
+
 rollbar:
   env: 'ROLLBAR_ENV'
   accessToken: 'ROLLBAR_ACCESS_TOKEN'

--- a/config/development.yml
+++ b/config/development.yml
@@ -2,9 +2,8 @@ accounts:
   tokenKey: 'dev_auth_token'
   passwordResetEmailEnabled: false
 
-defaultOTP: '1111'
-
-enableSMS: false
+sms:
+  enabled: false
 
 mongoDb:
   uri: 'mongodb://localhost:27017/boilerplate-mern-dev'

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -1,9 +1,8 @@
 accounts:
   passwordResetEmailEnabled: true
 
-defaultOTP: '1111'
-
-enableSMS: false
+sms:
+  enabled: false
 
 logger:
   transports: [ 'datadog' ]

--- a/config/preview.yml
+++ b/config/preview.yml
@@ -2,7 +2,7 @@ accounts:
   passwordResetEmailEnabled: true
 
 sms:
-  enabled: false
+  enabled: true
 
 logger:
   transports: [ 'datadog' ]

--- a/config/production.yml
+++ b/config/production.yml
@@ -2,8 +2,9 @@ accounts:
   passwordResetEmailEnabled: true
 
 defaultOTP: '1111'
+defaultPhoneNumber: '9999999999'
 
-enableSMS: false
+enableSMS: true
 
 logger:
   transports: [ 'datadog' ]

--- a/config/production.yml
+++ b/config/production.yml
@@ -1,10 +1,8 @@
 accounts:
   passwordResetEmailEnabled: true
 
-defaultOTP: '1111'
-defaultPhoneNumber: '9999999999'
-
-enableSMS: true
+sms:
+  enabled: true
 
 logger:
   transports: [ 'datadog' ]

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -8,7 +8,7 @@ mailer:
   forgetPasswordMailTemplateId: 'FORGOT_PASSWORD_MAIL_TEMPLATE_ID'
 
 sms:
-  enabled: true
+  enabled: false
 
 mongoDb:
   uri: 'mongodb://localhost:27017/boilerplate-mern-test'

--- a/config/testing.yml
+++ b/config/testing.yml
@@ -7,7 +7,8 @@ mailer:
   defaultEmailName: 'DEFAULT_EMAIL_NAME'
   forgetPasswordMailTemplateId: 'FORGOT_PASSWORD_MAIL_TEMPLATE_ID'
 
-enableSMS: true
+sms:
+  enabled: true
 
 mongoDb:
   uri: 'mongodb://localhost:27017/boilerplate-mern-test'

--- a/src/apps/backend/modules/communication/sms-service.ts
+++ b/src/apps/backend/modules/communication/sms-service.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '../config';
+import { isDefaultPhoneNumber } from '../util/phone-number-util';
 
 import TwilioService from './internals/twilio-service';
 import { SendSMSParams } from './types';
@@ -7,7 +8,8 @@ export default class SMSService {
   public static async sendSMS(params: SendSMSParams): Promise<void> {
     const enableSMS = ConfigService.getValue('enableSMS');
 
-    if (!enableSMS) {
+    // If SMS is disabled or the recipient phone number is the default phone number, do not send SMS
+    if (!enableSMS || isDefaultPhoneNumber(params.recipientPhone.phoneNumber)) {
       return;
     }
 

--- a/src/apps/backend/modules/communication/sms-service.ts
+++ b/src/apps/backend/modules/communication/sms-service.ts
@@ -1,15 +1,15 @@
 import { ConfigService } from '../config';
-import { isDefaultPhoneNumber } from '../util/phone-number-util';
+import { Logger } from '../logger';
 
 import TwilioService from './internals/twilio-service';
 import { SendSMSParams } from './types';
 
 export default class SMSService {
   public static async sendSMS(params: SendSMSParams): Promise<void> {
-    const enableSMS = ConfigService.getValue('enableSMS');
+    const isSmsEnabled = ConfigService.getValue('sms.enabled');
 
-    // If SMS is disabled or the recipient phone number is the default phone number, do not send SMS
-    if (!enableSMS || isDefaultPhoneNumber(params.recipientPhone.phoneNumber)) {
+    if (!isSmsEnabled) {
+      Logger.warn(`SMS not enabled. Could not send message - ${params.messageBody}`);
       return;
     }
 

--- a/src/apps/backend/modules/otp/internal/otp-util.ts
+++ b/src/apps/backend/modules/otp/internal/otp-util.ts
@@ -30,6 +30,10 @@ export default class OtpUtil {
 
     // If the phone number is the default phone number in production or if we are in a
     // non-production environment and the default OTP is set in the config, return the default OTP
+    console.log('isProdEnv', isProdEnv);
+    console.log('isDefaultPhoneNumber(phoneNumber)', isDefaultPhoneNumber(phoneNumber));
+    console.log('ConfigService.hasValue(\'defaultOTP\')', ConfigService.hasValue('defaultOTP'));
+    console.log('ConfigService.getValue<string>(\'defaultOTP\')', ConfigService.getValue<string>('defaultOTP'));
     if (
       (isProdEnv && isDefaultPhoneNumber(phoneNumber))
       || (!isProdEnv && ConfigService.hasValue('defaultOTP'))

--- a/src/apps/backend/modules/otp/internal/otp-util.ts
+++ b/src/apps/backend/modules/otp/internal/otp-util.ts
@@ -26,7 +26,7 @@ export default class OtpUtil {
   }
 
   public static getOtp(phoneNumber: string): string {
-    const isProdEnv = process.env.NODE_ENV === 'production';
+    const isProdEnv = process.env.NODE_CONFIG_ENV === 'production';
 
     // If the phone number is the default phone number in production or if we are in a
     // non-production environment and the default OTP is set in the config, return the default OTP

--- a/src/apps/backend/modules/otp/internal/otp-util.ts
+++ b/src/apps/backend/modules/otp/internal/otp-util.ts
@@ -30,10 +30,6 @@ export default class OtpUtil {
 
     // If the phone number is the default phone number in production or if we are in a
     // non-production environment and the default OTP is set in the config, return the default OTP
-    console.log('isProdEnv', isProdEnv);
-    console.log('isDefaultPhoneNumber(phoneNumber)', isDefaultPhoneNumber(phoneNumber));
-    console.log('ConfigService.hasValue(\'defaultOTP\')', ConfigService.hasValue('defaultOTP'));
-    console.log('ConfigService.getValue<string>(\'defaultOTP\')', ConfigService.getValue<string>('defaultOTP'));
     if (
       (isProdEnv && isDefaultPhoneNumber(phoneNumber))
       || (!isProdEnv && ConfigService.hasValue('defaultOTP'))

--- a/src/apps/backend/modules/otp/internal/otp-util.ts
+++ b/src/apps/backend/modules/otp/internal/otp-util.ts
@@ -1,5 +1,8 @@
 import _ from 'lodash';
 
+import { ConfigService } from '../../config';
+import { isDefaultPhoneNumber } from '../../util/phone-number-util';
+import { OTP_LENGTH } from '../constants';
 import { Otp } from '../types';
 
 import { OtpDB } from './store/otp-db';
@@ -20,5 +23,19 @@ export default class OtpUtil {
       otp += _.random(0, 9);
     }
     return otp;
+  }
+
+  public static getOtp(phoneNumber: string): string {
+    const isProdEnv = process.env.NODE_ENV === 'production';
+
+    // If the phone number is the default phone number in production or if we are in a
+    // non-production environment and the default OTP is set in the config, return the default OTP
+    if (
+      (isProdEnv && isDefaultPhoneNumber(phoneNumber))
+      || (!isProdEnv && ConfigService.hasValue('defaultOTP'))
+    ) {
+      return ConfigService.getValue<string>('defaultOTP');
+    }
+    return OtpUtil.generateOtp(OTP_LENGTH);
   }
 }

--- a/src/apps/backend/modules/otp/internal/otp-util.ts
+++ b/src/apps/backend/modules/otp/internal/otp-util.ts
@@ -26,15 +26,8 @@ export default class OtpUtil {
   }
 
   public static getOtp(phoneNumber: string): string {
-    const isProdEnv = process.env.NODE_CONFIG_ENV === 'production';
-
-    // If the phone number is the default phone number in production or if we are in a
-    // non-production environment and the default OTP is set in the config, return the default OTP
-    if (
-      (isProdEnv && isDefaultPhoneNumber(phoneNumber))
-      || (!isProdEnv && ConfigService.hasValue('defaultOTP'))
-    ) {
-      return ConfigService.getValue<string>('defaultOTP');
+    if (ConfigService.hasValue('otp.defaultOTP') && isDefaultPhoneNumber(phoneNumber)) {
+      return ConfigService.getValue<string>('otp.defaultOTP');
     }
     return OtpUtil.generateOtp(OTP_LENGTH);
   }

--- a/src/apps/backend/modules/otp/internal/otp-writer.ts
+++ b/src/apps/backend/modules/otp/internal/otp-writer.ts
@@ -1,6 +1,4 @@
 import { PhoneNumber } from '../../account/types';
-import { ConfigService } from '../../config';
-import { OTP_LENGTH } from '../constants';
 import {
   Otp,
   OtpExpiredError,
@@ -27,7 +25,7 @@ export default class OtpWriter {
       await previousOtpDb.save();
     }
 
-    const otp = ConfigService.hasValue('defaultOTP') ? ConfigService.getValue<string>('defaultOTP') : OtpUtil.generateOtp(OTP_LENGTH);
+    const otp = OtpUtil.getOtp(phoneNumber.phoneNumber);
 
     const otpDb = await OtpRepository.create({
       active: true,

--- a/src/apps/backend/modules/otp/otp-service.ts
+++ b/src/apps/backend/modules/otp/otp-service.ts
@@ -1,5 +1,6 @@
 import { PhoneNumber } from '../account/types';
 import { SMSService } from '../communication';
+import { isDefaultPhoneNumber } from '../util/phone-number-util';
 
 import OtpWriter from './internal/otp-writer';
 import {
@@ -12,10 +13,12 @@ export default class OtpService {
   ): Promise<Otp> {
     const otp = await OtpWriter.expirePreviousOtpAndCreateNewOtp(phoneNumber);
 
-    await SMSService.sendSMS({
-      messageBody: `${otp.otpCode} is your one time password to login.`,
-      recipientPhone: phoneNumber,
-    });
+    if (!isDefaultPhoneNumber(phoneNumber.phoneNumber)) {
+      await SMSService.sendSMS({
+        messageBody: `${otp.otpCode} is your one time password to login.`,
+        recipientPhone: phoneNumber,
+      });
+    }
 
     return otp;
   }

--- a/src/apps/backend/modules/util/phone-number-util.ts
+++ b/src/apps/backend/modules/util/phone-number-util.ts
@@ -1,0 +1,7 @@
+import { ConfigService } from '../config';
+
+export const isDefaultPhoneNumber = (phoneNumber: string): boolean => (
+  ConfigService.hasValue('defaultPhoneNumber')
+    && ConfigService.getValue<string>('defaultPhoneNumber')
+      === phoneNumber
+);

--- a/src/apps/backend/modules/util/phone-number-util.ts
+++ b/src/apps/backend/modules/util/phone-number-util.ts
@@ -1,7 +1,7 @@
 import { ConfigService } from '../config';
 
 export const isDefaultPhoneNumber = (phoneNumber: string): boolean => (
-  ConfigService.hasValue('defaultPhoneNumber')
-    && ConfigService.getValue<string>('defaultPhoneNumber')
+  ConfigService.hasValue('otp.defaultPhoneNumber')
+    && ConfigService.getValue<string>('otp.defaultPhoneNumber')
       === phoneNumber
 );

--- a/test/spec/communication/sms.spec.ts
+++ b/test/spec/communication/sms.spec.ts
@@ -14,7 +14,7 @@ describe('SMSService', () => {
       .returns('AC-random-id')
       .withArgs('twilio.verify.authToken')
       .returns('random-token')
-      .withArgs('enableSMS')
+      .withArgs('sms.enabled')
       .returns(true);
 
     // TODO: This needs to be fixed


### PR DESCRIPTION
## Description
_This PR is introduced to add support for default phone number along with default OTP so that OTP verifcation can be bypassed when using default phone number._

## Changes
- Added custom env variables for default OTP and default phone number
- `enableSMS` changed to -> `sms.enabled`
- Enabled SMS in preview env config so we can only bypass otp verification using default phone number and otp when using preview link

## Database schema changes
NA

## Tests
### Automated test cases added
NA

### Manual test cases run
- Verified If default number and OTP works for preview env
- Verified If OTP is displayed in console when in development env
- Able to add default number and otp in development config and able to bypass with default OTP
