### PR TITLE
Share one or more tasks existing users

### DIFF
--- a/src/apps/backend/modules/account/account-service.ts
+++ b/src/apps/backend/modules/account/account-service.ts
@@ -40,6 +40,10 @@ export default class AccountService {
 
     return account;
   }
+  
+  public static async getAllActiveAccounts(userId): Promise<Account[]>{
+    return AccountReader.getAllActiveAccounts(userId);
+  }
 
   public static async getAccountByUsernameAndPassword(
     password: string,

--- a/src/apps/backend/modules/account/internal/account-reader.ts
+++ b/src/apps/backend/modules/account/internal/account-reader.ts
@@ -12,9 +12,7 @@ import AccountUtil from './account-util';
 import AccountRepository from './store/account-repository';
 
 export default class AccountReader {
-  public static async getAccountByUsername(
-    username: string,
-  ): Promise<Account> {
+  public static async getAccountByUsername(username: string): Promise<Account> {
     const accountDb = await AccountRepository.findOne({
       username,
       active: true,
@@ -42,9 +40,12 @@ export default class AccountReader {
     return account;
   }
 
-  public static async getAccountById(
-    accountId: string,
-  ): Promise<Account> {
+  public static async getAllActiveAccounts(userId: string): Promise<Account[]> {
+    const accounts = await AccountRepository.find({ active: true, _id: {$ne: userId} });
+    return accounts.map(AccountUtil.convertAccountDBToAccount);
+  }
+
+  public static async getAccountById(accountId: string): Promise<Account> {
     const accountDb = await AccountRepository.findOne({
       _id: accountId,
       active: true,

--- a/src/apps/backend/modules/account/rest-api/account-controller.ts
+++ b/src/apps/backend/modules/account/rest-api/account-controller.ts
@@ -20,15 +20,9 @@ export class AccountController {
   createAccount = applicationController(
     async (req: Request<CreateAccountParams>, res: Response) => {
       let account: Account;
-      const {
-        firstName,
-        lastName,
-        password,
-        username,
-      } = req.body as CreateAccountParamsByUsernameAndPassword;
-      const {
-        phoneNumber,
-      } = req.body as CreateAccountParamsByPhoneNumber;
+      const { firstName, lastName, password, username } =
+        req.body as CreateAccountParamsByUsernameAndPassword;
+      const { phoneNumber } = req.body as CreateAccountParamsByPhoneNumber;
 
       if (username && password) {
         account = await AccountService.createAccountByUsernameAndPassword(
@@ -60,19 +54,21 @@ export class AccountController {
     },
   );
 
+  getAllActiveAccounts = applicationController(
+    async (req: Request<GetAccountParams>, res: Response) => {
+      const activeAccounts = await AccountService.getAllActiveAccounts(req.accountId);
+      const accountJsonArray = activeAccounts.map(serializeAccountAsJSON);
+      res.status(HttpStatusCodes.OK).send(accountJsonArray);
+    },
+  );
+
   updateAccount = applicationController(
     async (req: Request<UpdateAccountParams>, res: Response) => {
       const { accountId } = req.params;
       let account: Account;
-      const {
-        firstName,
-        lastName,
-      } = req.body as UpdateAccountDetailsParams;
+      const { firstName, lastName } = req.body as UpdateAccountDetailsParams;
 
-      const {
-        newPassword,
-        token,
-      } = req.body as ResetPasswordParams;
+      const { newPassword, token } = req.body as ResetPasswordParams;
 
       if (newPassword && token) {
         account = await AccountService.resetAccountPassword({

--- a/src/apps/backend/modules/account/rest-api/account-router.ts
+++ b/src/apps/backend/modules/account/rest-api/account-router.ts
@@ -17,5 +17,6 @@ export default class AccountRouter extends ApplicationRouter {
     router.use(accessAuthMiddleware);
 
     router.get('/:accountId', ctrl.getAccountById);
+    router.get('/', ctrl.getAllActiveAccounts);
   }
 }

--- a/src/apps/backend/modules/task/internal/store/task-db.ts
+++ b/src/apps/backend/modules/task/internal/store/task-db.ts
@@ -6,6 +6,7 @@ export interface TaskDB {
   active: boolean;
   description: string;
   title: string;
+  sharedWith: Types.ObjectId[];
 }
 
 export const TaskDbSchema: Schema = new Schema<TaskDB>(
@@ -29,6 +30,12 @@ export const TaskDbSchema: Schema = new Schema<TaskDB>(
       type: String,
       required: true,
     },
+    sharedWith: {
+      type: [Schema.Types.ObjectId],
+      ref: 'Account',
+      default: [],
+      required: true,
+    }
   },
   {
     collection: 'tasks',

--- a/src/apps/backend/modules/task/internal/task-reader.ts
+++ b/src/apps/backend/modules/task/internal/task-reader.ts
@@ -23,11 +23,12 @@ export default class TaskReader {
     return TaskUtil.convertTaskDBToTask(taskDb);
   }
 
-  public static async getTasksForAccount(params: GetAllTaskParams): Promise<Task []> {
-    const totalTasksCount = await TaskRepository.countDocuments({
-      account: params.accountId,
-      active: true,
-    });
+  public static async getTasksForAccount(params: GetAllTaskParams): Promise<Task[]> {
+    const FIND_COND = [
+      { account: params.accountId, active: true },
+      { active: true, sharedWith: params.accountId },
+    ];
+    const totalTasksCount = await TaskRepository.countDocuments(FIND_COND);
     const paginationParams: PaginationParams = {
       page: (params.page) ? (params.page) : 1,
       size: (params.size) ? (params.size) : totalTasksCount,
@@ -35,10 +36,10 @@ export default class TaskReader {
     const startIndex = (paginationParams.page - 1) * (paginationParams.size);
 
     const tasksDb = await TaskRepository
-      .find({ account: params.accountId, active: true })
+      .find({$or: FIND_COND})
       .limit(paginationParams.size)
       .skip(startIndex);
 
-    return tasksDb.map((taskDb) => TaskUtil.convertTaskDBToTask(taskDb));
+   return tasksDb.map((taskDb) => TaskUtil.convertTaskDBToTask(taskDb));
   }
 }

--- a/src/apps/backend/modules/task/internal/task-util.ts
+++ b/src/apps/backend/modules/task/internal/task-util.ts
@@ -9,6 +9,7 @@ export default class TaskUtil {
     task.account = taskDb.account.toString();
     task.description = taskDb.description;
     task.title = taskDb.title;
+    task.sharedWith = taskDb.sharedWith.map(toString);
     return task;
   }
 }

--- a/src/apps/backend/modules/task/internal/task-util.ts
+++ b/src/apps/backend/modules/task/internal/task-util.ts
@@ -9,7 +9,7 @@ export default class TaskUtil {
     task.account = taskDb.account.toString();
     task.description = taskDb.description;
     task.title = taskDb.title;
-    task.sharedWith = taskDb.sharedWith.map(toString);
+    task.sharedWith = taskDb.sharedWith.map(id=>id.toString());
     return task;
   }
 }

--- a/src/apps/backend/modules/task/internal/task-writer.ts
+++ b/src/apps/backend/modules/task/internal/task-writer.ts
@@ -1,6 +1,8 @@
+import { Types } from 'mongoose';
 import {
   CreateTaskParams,
   DeleteTaskParams,
+  ShareTasksParams,
   Task,
   TaskNotFoundError,
   UpdateTaskParams,
@@ -17,6 +19,7 @@ export default class TaskWriter {
       description: params.description,
       title: params.title,
       active: true,
+      sharedWith: [],
     });
     return TaskUtil.convertTaskDBToTask(createdTask);
   }
@@ -42,6 +45,22 @@ export default class TaskWriter {
     }
 
     return TaskUtil.convertTaskDBToTask(task);
+  }
+
+  public static async shareTasks(params: ShareTasksParams): Promise<void> {
+    const userIds = params.userIds.map(Types.ObjectId.createFromHexString);
+    await TaskRepository.updateMany(
+      {
+        _id: { $in: params.taskIds },
+        active: true,
+      },
+      {
+        $addToSet: {
+            'sharedWith': {$each: userIds},
+        },
+      },
+      { new: true },
+    );
   }
 
   public static async deleteTask(params: DeleteTaskParams): Promise<void> {

--- a/src/apps/backend/modules/task/rest-api/task-controller.ts
+++ b/src/apps/backend/modules/task/rest-api/task-controller.ts
@@ -8,60 +8,59 @@ import {
   DeleteTaskParams,
   GetTaskParams,
   UpdateTaskParams,
+  ShareTasksParams,
 } from '../types';
 
 import { serializeTaskAsJSON } from './task-serializer';
 
 export class TaskController {
-  createTask = applicationController(async (
-    req: Request<CreateTaskParams>,
-    res: Response,
-  ) => {
-    const task: Task = await TaskService.createTask({
-      accountId: req.accountId,
-      description: req.body.description,
-      title: req.body.title,
-    });
-    const taskJSON = serializeTaskAsJSON(task);
+  createTask = applicationController(
+    async (req: Request<CreateTaskParams>, res: Response) => {
+      const task: Task = await TaskService.createTask({
+        accountId: req.accountId,
+        description: req.body.description,
+        title: req.body.title,
+      });
+      const taskJSON = serializeTaskAsJSON(task);
 
-    res
-      .status(HttpStatusCodes.CREATED)
-      .send(taskJSON);
-  });
+      res.status(HttpStatusCodes.CREATED).send(taskJSON);
+    },
+  );
 
-  deleteTask = applicationController(async (
-    req: Request<DeleteTaskParams>,
-    res: Response,
-  ) => {
-    await TaskService.deleteTask({
-      accountId: req.accountId,
-      taskId: req.params.id,
-    });
+  shareTasks = applicationController(
+    async (req: Request<ShareTasksParams>, res: Response) => {
+      await TaskService.shareTasks({
+        taskIds: req.body.taskIds,
+        userIds: req.body.userIds,
+      });
+      res.status(HttpStatusCodes.OK).send();
+    },
+  );
 
-    res
-      .status(HttpStatusCodes.NO_CONTENT)
-      .send();
-  });
+  deleteTask = applicationController(
+    async (req: Request<DeleteTaskParams>, res: Response) => {
+      await TaskService.deleteTask({
+        accountId: req.accountId,
+        taskId: req.params.id,
+      });
 
-  getTask = applicationController(async (
-    req: Request<GetTaskParams>,
-    res: Response,
-  ) => {
-    const task = await TaskService.getTaskForAccount({
-      accountId: req.accountId,
-      taskId: req.params.id,
-    });
-    const taskJSON = serializeTaskAsJSON(task);
+      res.status(HttpStatusCodes.NO_CONTENT).send();
+    },
+  );
 
-    res
-      .status(HttpStatusCodes.OK)
-      .send(taskJSON);
-  });
+  getTask = applicationController(
+    async (req: Request<GetTaskParams>, res: Response) => {
+      const task = await TaskService.getTaskForAccount({
+        accountId: req.accountId,
+        taskId: req.params.id,
+      });
+      const taskJSON = serializeTaskAsJSON(task);
 
-  getTasks = applicationController(async (
-    req: Request,
-    res: Response,
-  ) => {
+      res.status(HttpStatusCodes.OK).send(taskJSON);
+    },
+  );
+
+  getTasks = applicationController(async (req: Request, res: Response) => {
     const page = +req.query.page;
     const size = +req.query.size;
     const params: GetAllTaskParams = {
@@ -73,25 +72,20 @@ export class TaskController {
     const tasks = await TaskService.getTasksForAccount(params);
     const tasksJSON = tasks.map((task) => serializeTaskAsJSON(task));
 
-    res
-      .status(HttpStatusCodes.OK)
-      .send(tasksJSON);
+    res.status(HttpStatusCodes.OK).send(tasksJSON);
   });
 
-  updateTask = applicationController(async (
-    req: Request<UpdateTaskParams>,
-    res: Response,
-  ) => {
-    const updatedTask: Task = await TaskService.updateTask({
-      accountId: req.accountId,
-      taskId: req.params.id,
-      description: req.body.description,
-      title: req.body.title,
-    });
-    const taskJSON = serializeTaskAsJSON(updatedTask);
+  updateTask = applicationController(
+    async (req: Request<UpdateTaskParams>, res: Response) => {
+      const updatedTask: Task = await TaskService.updateTask({
+        accountId: req.accountId,
+        taskId: req.params.id,
+        description: req.body.description,
+        title: req.body.title,
+      });
+      const taskJSON = serializeTaskAsJSON(updatedTask);
 
-    res
-      .status(HttpStatusCodes.OK)
-      .send(taskJSON);
-  });
+      res.status(HttpStatusCodes.OK).send(taskJSON);
+    },
+  );
 }

--- a/src/apps/backend/modules/task/rest-api/task-router.ts
+++ b/src/apps/backend/modules/task/rest-api/task-router.ts
@@ -13,6 +13,7 @@ export default class TaskRouter extends ApplicationRouter {
     router.post('/', ctrl.createTask);
     router.get('/', ctrl.getTasks);
     router.get('/:id', ctrl.getTask);
+    router.post('/share-tasks', ctrl.shareTasks);
     router.patch('/:id', ctrl.updateTask);
     router.delete('/:id', ctrl.deleteTask);
   }

--- a/src/apps/backend/modules/task/rest-api/task-router.ts
+++ b/src/apps/backend/modules/task/rest-api/task-router.ts
@@ -13,7 +13,7 @@ export default class TaskRouter extends ApplicationRouter {
     router.post('/', ctrl.createTask);
     router.get('/', ctrl.getTasks);
     router.get('/:id', ctrl.getTask);
-    router.post('/share-tasks', ctrl.shareTasks);
+    router.post('/share', ctrl.shareTasks);
     router.patch('/:id', ctrl.updateTask);
     router.delete('/:id', ctrl.deleteTask);
   }

--- a/src/apps/backend/modules/task/rest-api/task-serializer.ts
+++ b/src/apps/backend/modules/task/rest-api/task-serializer.ts
@@ -5,4 +5,5 @@ export const serializeTaskAsJSON = (task: Task): unknown => ({
   account: task.account,
   description: task.description,
   title: task.title,
+  sharedWith: task.sharedWith,
 });

--- a/src/apps/backend/modules/task/task-service.ts
+++ b/src/apps/backend/modules/task/task-service.ts
@@ -5,6 +5,7 @@ import {
   DeleteTaskParams,
   GetAllTaskParams,
   GetTaskParams,
+  ShareTasksParams,
   Task,
   UpdateTaskParams,
 } from './types';
@@ -26,7 +27,13 @@ export default class TaskService {
     return TaskReader.getTaskForAccount(params);
   }
 
-  public static async getTasksForAccount(params: GetAllTaskParams): Promise<Task[]> {
+  public static async getTasksForAccount(
+    params: GetAllTaskParams,
+  ): Promise<Task[]> {
     return TaskReader.getTasksForAccount(params);
+  } 
+
+  public static async shareTasks(params: ShareTasksParams): Promise<void> {
+    TaskWriter.shareTasks(params);
   }
 }

--- a/src/apps/backend/modules/task/types.ts
+++ b/src/apps/backend/modules/task/types.ts
@@ -6,6 +6,7 @@ export class Task {
   account: string;
   description: string;
   title: string;
+  sharedWith: string[];
 }
 
 export type GetAllTaskParams = {
@@ -30,6 +31,11 @@ export type UpdateTaskParams = {
   description: string;
   taskId: string;
   title: string;
+};
+
+export type ShareTasksParams = {
+  taskIds: string[];
+  userIds: string[];
 };
 
 export type DeleteTaskParams = {

--- a/src/apps/frontend/components/badge/index.tsx
+++ b/src/apps/frontend/components/badge/index.tsx
@@ -1,0 +1,9 @@
+import React, { PropsWithChildren } from 'react';
+
+const Badge: React.FC<PropsWithChildren> = ({ children }) => (
+  <span className="bg-blue-100 text-blue-800 text-xs font-medium me-2 px-2.5 py-0.5 rounded dark:bg-blue-900 dark:text-blue-300">
+    {children}
+  </span>
+);
+
+export default Badge;

--- a/src/apps/frontend/components/index.ts
+++ b/src/apps/frontend/components/index.ts
@@ -9,6 +9,7 @@ import HorizontalStackLayout from './layouts/horizontal-stack-layout';
 import VerticalStackLayout from './layouts/vertical-stack-layout';
 import MenuItem from './menu-item';
 import OTP from './otp';
+import Badge from './badge';
 import Select from './select';
 import Spinner from './spinner/spinner';
 import H2 from './typography/h2';
@@ -20,6 +21,7 @@ import ParagraphMedium from './typography/paragraph-medium';
 import ParagraphSmall from './typography/paragraph-small';
 
 export {
+  Badge,
   Button,
   Flex,
   FlexItem,

--- a/src/apps/frontend/components/sidebar/index.tsx
+++ b/src/apps/frontend/components/sidebar/index.tsx
@@ -56,12 +56,6 @@ const Sidebar: React.FC<SidebarProps> = ({
               title="Tasks"
             />
             <SidebarMenuItem
-              iconPath="/assets/img/icon/tasks-sidebar-icon.svg"
-              path={routes.SHARED}
-              setIsSidebarOpen={setIsSidebarOpen}
-              title="Shared with you"
-            />
-            <SidebarMenuItem
               iconPath="/assets/img/icon/profile-sidebar-icon.svg"
               path={routes.PROFILE}
               setIsSidebarOpen={setIsSidebarOpen}

--- a/src/apps/frontend/components/sidebar/index.tsx
+++ b/src/apps/frontend/components/sidebar/index.tsx
@@ -32,7 +32,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           aria-expanded={isSidebarOpen}
           className="block lg:hidden"
         >
-          <img src='/assets/img/icon/sidebar-arrow-icon.svg' alt="arrow icon" />
+          <img src="/assets/img/icon/sidebar-arrow-icon.svg" alt="arrow icon" />
         </button>
       </div>
 
@@ -44,16 +44,22 @@ const Sidebar: React.FC<SidebarProps> = ({
           </h3>
           <ul className="mb-6 flex flex-col gap-1.5">
             <SidebarMenuItem
-              iconPath='/assets/img/icon/dashboard-sidebar-icon.svg'
+              iconPath="/assets/img/icon/dashboard-sidebar-icon.svg"
               path={routes.DASHBOARD}
               setIsSidebarOpen={setIsSidebarOpen}
-              title='Dashboard'
+              title="Dashboard"
             />
             <SidebarMenuItem
-              iconPath='/assets/img/icon/tasks-sidebar-icon.svg'
+              iconPath="/assets/img/icon/tasks-sidebar-icon.svg"
               path={routes.TASKS}
               setIsSidebarOpen={setIsSidebarOpen}
-              title='Tasks'
+              title="Tasks"
+            />
+            <SidebarMenuItem
+              iconPath="/assets/img/icon/tasks-sidebar-icon.svg"
+              path={routes.SHARED}
+              setIsSidebarOpen={setIsSidebarOpen}
+              title="Shared with you"
             />
             <SidebarMenuItem
               iconPath="/assets/img/icon/profile-sidebar-icon.svg"

--- a/src/apps/frontend/constants/index.ts
+++ b/src/apps/frontend/constants/index.ts
@@ -15,6 +15,7 @@ const constant = {
   TITLE_MIN_LENGTH: 3,
   TITLE_VALIDATION_ERROR: 'Title should be at least 3 characters long',
   TOASTER_AUTO_HIDE_DURATION: 3000,
+  SHAREDWITH_VALIDATION_ERROR: 'Please share at least one user to share with',   
 };
 
 export default constant;

--- a/src/apps/frontend/constants/routes.ts
+++ b/src/apps/frontend/constants/routes.ts
@@ -10,6 +10,7 @@ const routes = {
   PROFILE_SETTINGS: '/profile/settings',
   SIGNUP: '/signup',
   TASKS: '/tasks',
+  SHARED: '/shared',
 };
 
 export default routes;

--- a/src/apps/frontend/contexts/account.provider.tsx
+++ b/src/apps/frontend/contexts/account.provider.tsx
@@ -2,12 +2,11 @@ import React, {
   createContext,
   PropsWithChildren,
   useContext,
+  useState,
 } from 'react';
 
 import { AccountService } from '../services';
-import {
-  Account, ApiResponse, AsyncError,
-} from '../types';
+import { Account, ApiResponse, AsyncError } from '../types';
 
 import useAsync from './async.hook';
 
@@ -19,26 +18,65 @@ type AccountContextType = {
   getAccountDetails: () => Promise<Account>;
   isAccountLoading: boolean;
   isDeleteAccountLoading: boolean;
+  getAllActiveAccounts: () => Promise<Account[]>;
+  isGetAllActiveAccountsLoading: boolean;
+  isGetAllActiveAccountsError: AsyncError;
+  allActiveAccounts: Account[];
+  allActiveAccountsList: Account[];
+  setActiveAccounts: React.Dispatch<React.SetStateAction<Account[]>>;
+  handleUserQuery: (q: string) => void;
+  activeAccountsToDisplay: Account[];
 };
 
 const AccountContext = createContext<AccountContextType | null>(null);
 
 const accountService = new AccountService();
 
-export const useAccountContext = (): AccountContextType => useContext(AccountContext);
+export const useAccountContext = (): AccountContextType =>
+  useContext(AccountContext);
 
-const getAccountDetailsFn = async (): Promise<ApiResponse<Account>> => accountService
-  .getAccountDetails();
+const getAccountDetailsFn = async (): Promise<ApiResponse<Account>> =>
+  accountService.getAccountDetails();
 
-const deleteAccountFn = async (): Promise<ApiResponse<void>> => accountService.deleteAccount();
+const deleteAccountFn = async (): Promise<ApiResponse<void>> =>
+  accountService.deleteAccount();
 
 export const AccountProvider: React.FC<PropsWithChildren> = ({ children }) => {
+  const [allActiveAccountsList, setActiveAccounts] = useState<Account[]>([]);
+  const [activeAccountsToDisplay, setActiveAccountsToDisplay] = useState<
+    Account[]
+  >([]);
+
+  const getAllActiveAccountsFn = async (): Promise<ApiResponse<Account[]>> => {
+    const response = await accountService.getAllActiveAccounts();
+    setActiveAccounts(response.data);
+    setActiveAccountsToDisplay(response.data);
+    return response;
+  };
+
+  const handleUserQuery = (query: string): void => {
+    setActiveAccountsToDisplay(
+      allActiveAccountsList.filter(
+        (item) =>
+          item.username.toLowerCase().includes(query.toLowerCase()) ||
+          item.displayName().toLowerCase().includes(query.toLowerCase()),
+      ),
+    );
+  };
+
   const {
     isLoading: isAccountLoading,
     error: accountError,
     result: accountDetails,
     asyncCallback: getAccountDetails,
   } = useAsync(getAccountDetailsFn);
+
+  const {
+    isLoading: isGetAllActiveAccountsLoading,
+    error: isGetAllActiveAccountsError,
+    result: allActiveAccounts,
+    asyncCallback: getAllActiveAccounts,
+  } = useAsync(getAllActiveAccountsFn);
 
   const {
     isLoading: isDeleteAccountLoading,
@@ -49,14 +87,21 @@ export const AccountProvider: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <AccountContext.Provider
       value={{
-        accountDetails:
-          new Account({ ...accountDetails }), // creating an instance to access its methods
+        accountDetails: new Account({ ...accountDetails }), // creating an instance to access its methods
         accountError,
         deleteAccount,
         deleteAccountError,
         getAccountDetails,
         isAccountLoading,
         isDeleteAccountLoading,
+        getAllActiveAccounts,
+        isGetAllActiveAccountsLoading,
+        isGetAllActiveAccountsError,
+        allActiveAccounts,
+        allActiveAccountsList,
+        setActiveAccounts,
+        handleUserQuery,
+        activeAccountsToDisplay,
       }}
     >
       {children}

--- a/src/apps/frontend/contexts/task.provider.tsx
+++ b/src/apps/frontend/contexts/task.provider.tsx
@@ -26,6 +26,10 @@ type TaskContextType = {
   updateTask: (taskId: string, taskData: Partial<Task>) => Promise<Task>;
   updateTaskError: AsyncError;
   updatedTask: Task;
+  shareTasks: (taskIds: string[], userIds: string[]) => Promise<Task[]>;
+  shareTaskError: AsyncError;
+  shareTaskResult: Task[];
+  isShareTaskLoading: boolean;
 };
 
 const TaskContext = createContext<TaskContextType | null>(null);
@@ -43,6 +47,11 @@ const updateTaskFn = async (
   taskId: string,
   taskData: Task,
 ): Promise<ApiResponse<Task>> => taskService.updateTask(taskId, taskData);
+
+const shareTaskFn = async (
+  taskIds: string[],
+  userIds: string[],
+): Promise<ApiResponse<Task[]>> => taskService.shareTasks(taskIds, userIds);
 
 const deleteTaskFn = async (taskId: string):
 Promise<ApiResponse<void>> => taskService.deleteTask(taskId);
@@ -77,6 +86,13 @@ export const TaskProvider: React.FC<PropsWithChildren> = ({ children }) => {
     result: updatedTask,
   } = useAsync(updateTaskFn);
 
+    const {
+      asyncCallback: shareTasks,
+      error: shareTaskError,
+      isLoading: isShareTaskLoading,
+      result: shareTaskResult,
+    } = useAsync(shareTaskFn);
+
   const {
     asyncCallback: deleteTask,
     error: deleteTaskError,
@@ -103,6 +119,10 @@ export const TaskProvider: React.FC<PropsWithChildren> = ({ children }) => {
         updateTask,
         updateTaskError,
         updatedTask,
+        shareTasks,
+        shareTaskError,
+        shareTaskResult,
+        isShareTaskLoading,
       }}
     >
       {children}

--- a/src/apps/frontend/pages/tasks/account-item.tsx
+++ b/src/apps/frontend/pages/tasks/account-item.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { HorizontalStackLayout, Input, ParagraphSmall } from '../../components';
+import { Account } from '../../types';
+
+interface AccountItemProps {
+  account: Account;
+  handleToggle: (userId: string) => void;
+  selected: boolean;
+}
+
+const AccountItem: React.FC<AccountItemProps> = ({ account, handleToggle, selected }) => {
+  return (
+    <HorizontalStackLayout gap={7}>
+      <div>
+        <Input
+          error=""
+          type="checkbox"
+          checked={selected}
+          onChange={() => handleToggle(account.id)}
+        />
+      </div>
+      <ParagraphSmall>
+        {account.displayName()} ({account.username})
+      </ParagraphSmall>
+    </HorizontalStackLayout>
+  );
+};
+
+export default AccountItem;

--- a/src/apps/frontend/pages/tasks/index.tsx
+++ b/src/apps/frontend/pages/tasks/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 
 import { HeadingMedium, VerticalStackLayout } from '../../components';
@@ -9,18 +9,18 @@ import TaskHeader from './task-header';
 import TaskSection from './task-section';
 
 const Tasks: React.FC = () => {
+  const [selectedTasks, setSelectedTasks] = useState([]);
   const onError = (error: AsyncError) => {
     toast.error(error.message);
   };
 
-  const {
-    deleteTask, getTasks, isGetTasksLoading, setTasksList, tasksList,
-  } = useTaskContext();
+  const { deleteTask, getTasks, isGetTasksLoading, setTasksList, tasksList } =
+    useTaskContext();
 
   useEffect(() => {
-    getTasks()
-      .catch((error) => onError(error as AsyncError));
+    getTasks().catch((error) => onError(error as AsyncError));
   }, []);
+
 
   const handleDeleteTask = (taskId: string) => {
     deleteTask(taskId)
@@ -30,15 +30,28 @@ const Tasks: React.FC = () => {
       .catch((error) => onError(error as AsyncError));
   };
 
+  const handleTaskCheckBoxToggle = (taskId: string) : void => {
+    setSelectedTasks(
+      selectedTasks.includes(taskId)
+        ? selectedTasks.filter((id) => id !== taskId)
+        : [...selectedTasks, taskId],
+    );
+  };
+
+  const resetSelectedTasks = (): void => {
+    setSelectedTasks([]);
+  }
   return (
     <div className="mx-auto max-w-5xl">
       <VerticalStackLayout gap={7}>
         <HeadingMedium>TaskList</HeadingMedium>
-        <TaskHeader />
+        <TaskHeader selectedTasks={selectedTasks} resetSelectedTasks={resetSelectedTasks}/>
         <TaskSection
+          handleTaskCheckBoxToggle={handleTaskCheckBoxToggle}
           tasks={tasksList}
           isGetTasksLoading={isGetTasksLoading}
           handleDeleteTask={handleDeleteTask}
+          selectedTasks={selectedTasks}
         />
       </VerticalStackLayout>
     </div>

--- a/src/apps/frontend/pages/tasks/share-tasks-modal.tsx
+++ b/src/apps/frontend/pages/tasks/share-tasks-modal.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+
+import {
+  Button,
+  FormControl,
+  HeadingSmall,
+  Input,
+  ParagraphSmall,
+  Spinner,
+  VerticalStackLayout,
+} from '../../components';
+import Modal from '../../components/modal';
+import { AsyncError } from '../../types';
+import { ButtonKind, ButtonSize, ButtonType } from '../../types/button';
+import { useAccountContext, useTaskContext } from '../../contexts';
+import AccountItem from './account-item';
+import toast from 'react-hot-toast';
+
+interface ShareTasksModalProps {
+  btnText: string;
+  isModalOpen: boolean;
+  setIsModalOpen: (open: boolean) => void;
+  taskIds: string[];
+  resetSelectedTasks: () => void;
+}
+
+const ShareTasksModal: React.FC<ShareTasksModalProps> = ({
+  btnText,
+  isModalOpen,
+  setIsModalOpen,
+  resetSelectedTasks,
+  taskIds,
+}) => {
+  const {
+    getAllActiveAccounts,
+    activeAccountsToDisplay,
+    isGetAllActiveAccountsLoading,
+    handleUserQuery,
+  } = useAccountContext();
+
+  const { shareTasks, isShareTaskLoading } = useTaskContext();
+
+  useEffect(() => {
+    getAllActiveAccounts().catch((error) => onError(error as AsyncError));
+  }, []);
+
+  const [selectedUsers, setSelectedUsers] = useState([]);
+
+  const onSuccess = () => {
+    toast.success(`${taskIds.length===1?'Task':'Tasks'} shared successfully`);
+    setIsModalOpen(false);
+    setSelectedUsers([]);
+    handleUserQuery('');
+    resetSelectedTasks();
+  };
+
+  const onError = (error: AsyncError) => {
+    toast.error(error.message);
+  };
+
+  const handleSumbit = () => {
+    shareTasks(taskIds, selectedUsers)
+      .then(() => onSuccess())
+      .catch((error) => onError(error));
+  };
+
+  const handleToggle = (userId: string) => {
+    setSelectedUsers(
+      selectedUsers.includes(userId)
+        ? selectedUsers.filter((id) => id !== userId)
+        : [...selectedUsers, userId],
+    );
+  };
+
+  return (
+    <Modal isModalOpen={isModalOpen}>
+      <div className="absolute right-1 top-1 sm:right-5 sm:top-5">
+        <Button
+          onClick={() => setIsModalOpen(false)}
+          kind={ButtonKind.TERTIARY}
+          startEnhancer={
+            <img
+              src="assets/svg/close-icon.svg"
+              alt="close-icon"
+              className="fill-current"
+            />
+          }
+        ></Button>
+      </div>
+
+      <VerticalStackLayout gap={5}>
+        <HeadingSmall>
+          Share {taskIds.length === 1 ? 'task' : 'tasks'} with other users
+        </HeadingSmall>
+        <Input
+          data-testid="title"
+          disabled={isGetAllActiveAccountsLoading}
+          error=""
+          onChange={(e) => handleUserQuery(e.target.value)}
+          placeholder="Search user by name or email"
+          type="text"
+        />
+        <FormControl error="" label={'Share task(s) with'}>
+          {isGetAllActiveAccountsLoading ? (
+            <Spinner />
+          ) : activeAccountsToDisplay.length > 0 ? (
+            activeAccountsToDisplay.map((accountDetails) => (
+              <AccountItem
+                account={accountDetails}
+                handleToggle={handleToggle}
+                selected={selectedUsers.includes(accountDetails.id)}
+              />
+            ))
+          ) : (
+            <ParagraphSmall>No users to display</ParagraphSmall>
+          )}
+        </FormControl>
+        <Button
+          type={ButtonType.SUBMIT}
+          onClick={handleSumbit}
+          disabled={selectedUsers.length === 0}
+          size={ButtonSize.DEFAULT}
+          isLoading={isShareTaskLoading}
+          startEnhancer={
+            <img src="assets/svg/share-icon.svg" alt="Share Icon" />
+          }
+        >
+          {btnText}
+        </Button>
+      </VerticalStackLayout>
+    </Modal>
+  );
+};
+
+export default ShareTasksModal;

--- a/src/apps/frontend/pages/tasks/task-header.tsx
+++ b/src/apps/frontend/pages/tasks/task-header.tsx
@@ -1,19 +1,27 @@
 import React, { useState } from 'react';
 import toast from 'react-hot-toast';
 
-import { Button, HeadingLarge } from '../../components';
+import { Button, HeadingLarge, HorizontalStackLayout } from '../../components';
 import { AsyncError } from '../../types';
-import { ButtonSize } from '../../types/button';
+import { ButtonKind, ButtonSize } from '../../types/button';
 
 import TaskModal from './task-modal';
 import useTaskForm from './tasks-form.hook';
+import ShareTasksModal from './share-tasks-modal';
 
 interface TaskHeaderProps {
   onError?: (error: AsyncError) => void;
+  selectedTasks: string[];
+  resetSelectedTasks: () => void;
 }
 
-const TaskHeader: React.FC<TaskHeaderProps> = ({ onError }) => {
+const TaskHeader: React.FC<TaskHeaderProps> = ({
+  onError,
+  selectedTasks,
+  resetSelectedTasks,
+}) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isShareTasksModalOpen, setIsShareTasksModalOpen] = useState(false);
 
   const onSuccess = () => {
     toast.success('Task has been added successfully');
@@ -31,7 +39,19 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({ onError }) => {
         <div className="pl-2">
           <HeadingLarge>Tasks</HeadingLarge>
         </div>
-        <div>
+        <HorizontalStackLayout gap={3}>
+          <Button
+            onClick={() => setIsShareTasksModalOpen(!isShareTasksModalOpen)}
+            size={ButtonSize.COMPACT}
+            kind={ButtonKind.PRIMARY}
+            disabled={selectedTasks.length === 0}
+            startEnhancer={
+              <img src="assets/svg/share-icon.svg" alt="Share Icon" />
+            }
+          >
+            Share task(s)
+          </Button>
+
           <Button
             onClick={() => setIsModalOpen(!isModalOpen)}
             size={ButtonSize.COMPACT}
@@ -41,12 +61,19 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({ onError }) => {
           >
             Add task
           </Button>
-        </div>
+        </HorizontalStackLayout>
         <TaskModal
           formik={addTaskFormik}
           isModalOpen={isModalOpen}
           setIsModalOpen={setIsModalOpen}
           btnText={'Add Task'}
+        />
+        <ShareTasksModal
+          taskIds={selectedTasks}
+          resetSelectedTasks={resetSelectedTasks}
+          isModalOpen={isShareTasksModalOpen}
+          setIsModalOpen={setIsShareTasksModalOpen}
+          btnText={'Share Task'}
         />
       </div>
     </div>

--- a/src/apps/frontend/pages/tasks/task-section.checkbox.tsx
+++ b/src/apps/frontend/pages/tasks/task-section.checkbox.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface TaskSectionCheckBoxProps {
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const TaskSectionCheckbox: React.FC<TaskSectionCheckBoxProps> = ({
+  onChange,
+}) => (
+  <div className="relative pt-0.5">
+    <input
+      type="checkbox"
+      id="formCheckbox"
+      className="taskCheckbox sr-only"
+      onChange={onChange}
+    />
+    <div className="box mr-3 flex size-5 items-center justify-center rounded border border-stroke dark:border-form-strokedark dark:bg-form-input">
+      <span className="opacity-0">
+        <img
+          alt="checkbox tick mark icon"
+          className="size-3"
+          src="/assets/img/icon/form-checkbox-checkmark.svg"
+        />
+      </span>
+    </div>
+  </div>
+);
+
+export default TaskSectionCheckbox;

--- a/src/apps/frontend/pages/tasks/task-section.tsx
+++ b/src/apps/frontend/pages/tasks/task-section.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import toast from 'react-hot-toast';
 
 import {
+  Badge,
   Button,
   HeadingSmall,
   HorizontalStackLayout,
@@ -18,6 +19,7 @@ import { Task } from '../../types/task';
 
 import TaskModal from './task-modal';
 import useTaskForm from './tasks-form.hook';
+import { getAccessTokenFromStorage } from '../../utils/storage-util';
 
 interface TaskSectionProps {
   handleDeleteTask: (taskId: string) => void;
@@ -37,6 +39,8 @@ const TaskSection: React.FC<TaskSectionProps> = ({
   selectedTasks,
 }) => {
   const [updateTaskModal, setUpdateTaskModal] = useState(false);
+
+  const userAccessToken = getAccessTokenFromStorage();
 
   const onSuccess = () => {
     toast.success('Task has been updated successfully');
@@ -72,54 +76,65 @@ const TaskSection: React.FC<TaskSectionProps> = ({
         </HeadingSmall>
       )}
 
-      {tasks.map((task) => (
-        <div
-          className="relative rounded-sm border border-stroke bg-white p-9 shadow-default"
-          key={task.id}
-        >
-          <HorizontalStackLayout gap={5}>
-            <div>
-              <Input
-                type="checkbox"
-                error=""
-                checked={selectedTasks.includes(task.id)}
-                onChange={() => handleTaskCheckBoxToggle(task.id)}
-              />
-            </div>
-            <div>
-              <VerticalStackLayout gap={3}>
-                <LabelLarge>{task.title}</LabelLarge>
-                <ParagraphSmall>{task.description}</ParagraphSmall>
-              </VerticalStackLayout>
-            </div>
-          </HorizontalStackLayout>
+      {tasks.map((task) => {
+        return (
+          <div
+            className="relative rounded-sm border border-stroke bg-white p-9 shadow-default"
+            key={task.id}
+          >
+            <HorizontalStackLayout gap={5}>
+              <div>
+                <Input
+                  type="checkbox"
+                  error=""
+                  checked={selectedTasks.includes(task.id)}
+                  onChange={() => handleTaskCheckBoxToggle(task.id)}
+                />
+              </div>
+              <div>
+                <VerticalStackLayout gap={3}>
+                  <HorizontalStackLayout gap={3}>
+                    <div>
+                      <LabelLarge>{task.title}</LabelLarge>
+                    </div>
+                    <div>
+                      {task.sharedWith?.includes(userAccessToken.accountId) ? (
+                        <Badge>Shared with you</Badge>
+                      ) : null}
+                    </div>
+                  </HorizontalStackLayout>
+                  <ParagraphSmall>{task.description}</ParagraphSmall>
+                </VerticalStackLayout>
+              </div>
+            </HorizontalStackLayout>
 
-          <div className="absolute right-4 top-4">
-            <MenuItem>
-              <Button
-                onClick={() => handleTaskOperation(task)}
-                kind={ButtonKind.SECONDARY}
-                size={ButtonSize.DEFAULT}
-                startEnhancer={
-                  <img src="assets/svg/edit-icon.svg" alt="Edit task" />
-                }
-              >
-                Edit
-              </Button>
-              <Button
-                onClick={() => handleDeleteTask(task.id)}
-                kind={ButtonKind.SECONDARY}
-                size={ButtonSize.DEFAULT}
-                startEnhancer={
-                  <img src="assets/svg/delete-icon.svg" alt="Delete task" />
-                }
-              >
-                Delete
-              </Button>
-            </MenuItem>
+            <div className="absolute right-4 top-4">
+              <MenuItem>
+                <Button
+                  onClick={() => handleTaskOperation(task)}
+                  kind={ButtonKind.SECONDARY}
+                  size={ButtonSize.DEFAULT}
+                  startEnhancer={
+                    <img src="assets/svg/edit-icon.svg" alt="Edit task" />
+                  }
+                >
+                  Edit
+                </Button>
+                <Button
+                  onClick={() => handleDeleteTask(task.id)}
+                  kind={ButtonKind.SECONDARY}
+                  size={ButtonSize.DEFAULT}
+                  startEnhancer={
+                    <img src="assets/svg/delete-icon.svg" alt="Delete task" />
+                  }
+                >
+                  Delete
+                </Button>
+              </MenuItem>
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
 
       <TaskModal
         formik={updateTaskFormik}

--- a/src/apps/frontend/pages/tasks/task-section.tsx
+++ b/src/apps/frontend/pages/tasks/task-section.tsx
@@ -4,6 +4,8 @@ import toast from 'react-hot-toast';
 import {
   Button,
   HeadingSmall,
+  HorizontalStackLayout,
+  Input,
   LabelLarge,
   MenuItem,
   ParagraphSmall,
@@ -19,9 +21,11 @@ import useTaskForm from './tasks-form.hook';
 
 interface TaskSectionProps {
   handleDeleteTask: (taskId: string) => void;
+  handleTaskCheckBoxToggle: (taskId: string) => void;
   isGetTasksLoading: boolean;
   onError?: (error: AsyncError) => void;
   tasks: Task[];
+  selectedTasks: string[];
 }
 
 const TaskSection: React.FC<TaskSectionProps> = ({
@@ -29,6 +33,8 @@ const TaskSection: React.FC<TaskSectionProps> = ({
   isGetTasksLoading,
   onError,
   tasks,
+  handleTaskCheckBoxToggle,
+  selectedTasks,
 }) => {
   const [updateTaskModal, setUpdateTaskModal] = useState(false);
 
@@ -71,10 +77,22 @@ const TaskSection: React.FC<TaskSectionProps> = ({
           className="relative rounded-sm border border-stroke bg-white p-9 shadow-default"
           key={task.id}
         >
-          <VerticalStackLayout gap={3}>
-            <LabelLarge>{task.title}</LabelLarge>
-            <ParagraphSmall>{task.description}</ParagraphSmall>
-          </VerticalStackLayout>
+          <HorizontalStackLayout gap={5}>
+            <div>
+              <Input
+                type="checkbox"
+                error=""
+                checked={selectedTasks.includes(task.id)}
+                onChange={() => handleTaskCheckBoxToggle(task.id)}
+              />
+            </div>
+            <div>
+              <VerticalStackLayout gap={3}>
+                <LabelLarge>{task.title}</LabelLarge>
+                <ParagraphSmall>{task.description}</ParagraphSmall>
+              </VerticalStackLayout>
+            </div>
+          </HorizontalStackLayout>
 
           <div className="absolute right-4 top-4">
             <MenuItem>

--- a/src/apps/frontend/pages/tasks/tasks-form.hook.ts
+++ b/src/apps/frontend/pages/tasks/tasks-form.hook.ts
@@ -33,6 +33,7 @@ const useTaskForm = ({ onError, onSuccess }: TaskFormProps) => {
       id: '',
       description: '',
       title: '',
+      sharedWith: [],
     },
     validationSchema: Yup.object({
       title: Yup.string()
@@ -70,6 +71,7 @@ const useTaskForm = ({ onError, onSuccess }: TaskFormProps) => {
       id: '',
       description: '',
       title: '',
+      sharedWith: [],
     },
     validationSchema: Yup.object({
       title: Yup.string()

--- a/src/apps/frontend/routes/protected.tsx
+++ b/src/apps/frontend/routes/protected.tsx
@@ -41,14 +41,6 @@ export const protectedRoutes = [
         ),
       },
       {
-        path: routes.SHARED,
-        element: (
-          <TaskProvider>
-            <Tasks />
-          </TaskProvider>
-        ),
-      },
-      {
         path: routes.PROFILE_SETTINGS,
         element: <ProfileSettings />,
       },

--- a/src/apps/frontend/routes/protected.tsx
+++ b/src/apps/frontend/routes/protected.tsx
@@ -41,6 +41,14 @@ export const protectedRoutes = [
         ),
       },
       {
+        path: routes.SHARED,
+        element: (
+          <TaskProvider>
+            <Tasks />
+          </TaskProvider>
+        ),
+      },
+      {
         path: routes.PROFILE_SETTINGS,
         element: <ProfileSettings />,
       },

--- a/src/apps/frontend/services/account.service.ts
+++ b/src/apps/frontend/services/account.service.ts
@@ -1,5 +1,6 @@
-import { ApiResponse } from '../types';
+import { ApiError, ApiResponse } from '../types';
 import { Account } from '../types/account';
+import { JsonObject } from '../types/common-types';
 import { getAccessTokenFromStorage } from '../utils/storage-util';
 
 import APIService from './api.service';
@@ -13,6 +14,27 @@ export default class AccountService extends APIService {
         Authorization: `Bearer ${userAccessToken.token}`,
       },
     });
+  };
+
+  getAllActiveAccounts = async (): Promise<ApiResponse<Account[]>> => {
+    try {
+      const userAccessToken = getAccessTokenFromStorage();
+
+      const response = await this.apiClient.get(`/accounts`, {
+        headers: {
+          Authorization: `Bearer ${userAccessToken.token}`,
+        },
+      });
+      const accounts: Account[] = (response.data as JsonObject[])
+      .filter((account) => account.id !== userAccessToken.accountId)
+      .map((accountData) => new Account(accountData));
+      return new ApiResponse(accounts, undefined);
+    } catch (e) {
+      return new ApiResponse(
+        undefined,
+        new ApiError(e.response.data as JsonObject),
+      );
+    }
   };
 
   deleteAccount = async (): Promise<ApiResponse<void>> => {

--- a/src/apps/frontend/services/task.service.ts
+++ b/src/apps/frontend/services/task.service.ts
@@ -81,7 +81,7 @@ export default class TaskService extends APIService {
     try {
       const userAccessToken = getAccessTokenFromStorage();
       await this.apiClient.post(
-        '/tasks/share-tasks',
+        '/tasks/share',
         { taskIds, userIds },
         {
           headers: {

--- a/src/apps/frontend/services/task.service.ts
+++ b/src/apps/frontend/services/task.service.ts
@@ -13,7 +13,8 @@ export default class TaskService extends APIService {
     try {
       const userAccessToken = getAccessTokenFromStorage();
       const response = await this.apiClient.post(
-        '/tasks', { title, description },
+        '/tasks',
+        { title, description },
         {
           headers: {
             Authorization: `Bearer ${userAccessToken.token}`,
@@ -22,25 +23,30 @@ export default class TaskService extends APIService {
       );
       return new ApiResponse(new Task(response.data as JsonObject), undefined);
     } catch (e) {
-      return new ApiResponse(undefined, new ApiError(e.response.data as JsonObject));
+      return new ApiResponse(
+        undefined,
+        new ApiError(e.response.data as JsonObject),
+      );
     }
   };
 
   getTasks = async (): Promise<ApiResponse<Task[]>> => {
     try {
       const userAccessToken = getAccessTokenFromStorage();
-      const response = await this.apiClient.get(
-        '/tasks',
-        {
-          headers: {
-            Authorization: `Bearer ${userAccessToken.token}`,
-          },
+      const response = await this.apiClient.get('/tasks', {
+        headers: {
+          Authorization: `Bearer ${userAccessToken.token}`,
         },
+      });
+      const tasks: Task[] = (response.data as JsonObject[]).map(
+        (taskData) => new Task(taskData),
       );
-      const tasks: Task[] = (response.data as JsonObject[]).map((taskData) => new Task(taskData));
       return new ApiResponse(tasks, undefined);
     } catch (e) {
-      return new ApiResponse(undefined, new ApiError(e.response.data as JsonObject));
+      return new ApiResponse(
+        undefined,
+        new ApiError(e.response.data as JsonObject),
+      );
     }
   };
 
@@ -51,7 +57,8 @@ export default class TaskService extends APIService {
     try {
       const userAccessToken = getAccessTokenFromStorage();
       const response = await this.apiClient.patch(
-        `/tasks/${taskId}`, taskData,
+        `/tasks/${taskId}`,
+        taskData,
         {
           headers: {
             Authorization: `Bearer ${userAccessToken.token}`,
@@ -60,7 +67,34 @@ export default class TaskService extends APIService {
       );
       return new ApiResponse(new Task(response.data as JsonObject), undefined);
     } catch (e) {
-      return new ApiResponse(undefined, new ApiError(e.response.data as JsonObject));
+      return new ApiResponse(
+        undefined,
+        new ApiError(e.response.data as JsonObject),
+      );
+    }
+  };
+
+  shareTasks = async (
+    taskIds: string[],
+    userIds: string[],
+  ): Promise<ApiResponse<Task[]>> => {
+    try {
+      const userAccessToken = getAccessTokenFromStorage();
+      await this.apiClient.post(
+        '/tasks/share-tasks',
+        { taskIds, userIds },
+        {
+          headers: {
+            Authorization: `Bearer ${userAccessToken.token}`,
+          },
+        },
+      );
+      return new ApiResponse(undefined, undefined);
+    } catch (e) {
+      return new ApiResponse(
+        undefined,
+        new ApiError(e.response.data as JsonObject),
+      );
     }
   };
 
@@ -74,7 +108,10 @@ export default class TaskService extends APIService {
       });
       return new ApiResponse(undefined, undefined);
     } catch (e) {
-      return new ApiResponse(undefined, new ApiError(e.response.data as JsonObject));
+      return new ApiResponse(
+        undefined,
+        new ApiError(e.response.data as JsonObject),
+      );
     }
   };
 }

--- a/src/apps/frontend/types/task-share.ts
+++ b/src/apps/frontend/types/task-share.ts
@@ -1,0 +1,9 @@
+import { JsonObject } from './common-types';
+
+export class TaskShare {
+    sharedWith: string[];
+
+    constructor(json: JsonObject) {
+        this.sharedWith = json.sharedWith as string[];
+    }
+}

--- a/src/apps/frontend/types/task.ts
+++ b/src/apps/frontend/types/task.ts
@@ -8,6 +8,7 @@ export class Task {
   id: string;
   description: string;
   title: string;
+  sharedWith: string[];
 
   constructor(json: JsonObject) {
     this.id = json.id as string;

--- a/src/apps/frontend/types/task.ts
+++ b/src/apps/frontend/types/task.ts
@@ -14,5 +14,6 @@ export class Task {
     this.id = json.id as string;
     this.description = json.description as string;
     this.title = json.title as string;
+    this.sharedWith = json.sharedWith as string[];
   }
 }

--- a/src/assets/svg/share-icon.svg
+++ b/src/assets/svg/share-icon.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="16"
+  height="17"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  class="feather feather-share-2"
+>
+  <circle cx="18" cy="5" r="3"></circle>
+  <circle cx="6" cy="12" r="3"></circle>
+  <circle cx="18" cy="19" r="3"></circle>
+  <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"></line>
+  <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"></line>
+</svg>


### PR DESCRIPTION
## Description
_A feature to be able to share one or more tasks with the existing users. To be able to add this functionality, a couple of new endpoints have been created:_

1. POST `/tasks/share-tasks` - To share one or more tasks with users.
> Request Body: `{taskIds: string[], userIds:[]}`
Response: void

2. GET `/accounts` - To fetch all active users to share the task with.

## Database schema changes
_A new field `sharedWith` has been added to the `Task` schema to hold IDs of the users with whom the task is shared_

## Tests
### Automated test cases added
- _Description of automated test 1_
- _Description of automated test 2_
- _Description of automated test 3_

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- _Description of manual test 1_
- _Description of manual test 2_
- _Description of manual test 3_
