### PR TITLE
Fix: Mongoose schema type mismatch lint error in application repository

### DIFF
--- a/src/apps/backend/modules/account/internal/store/account-db.ts
+++ b/src/apps/backend/modules/account/internal/store/account-db.ts
@@ -15,7 +15,7 @@ export interface AccountDB {
   username: string;
 }
 
-export const AccountDbSchema: Schema = new Schema<AccountDB>(
+export const AccountDbSchema = new Schema<AccountDB>(
   {
     active: {
       type: Boolean,

--- a/src/apps/backend/modules/application/application-repository.ts
+++ b/src/apps/backend/modules/application/application-repository.ts
@@ -22,7 +22,7 @@ const getDatabaseConnection = (): mongoose.Connection => {
 
 export default function ApplicationRepository<T>(
   name: string,
-  schema: mongoose.Schema,
+  schema: mongoose.Schema<T>,
   collection?: string,
 ): mongoose.Model<T> {
   const connection = getDatabaseConnection();
@@ -30,8 +30,5 @@ export default function ApplicationRepository<T>(
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   connection.syncIndexes();
 
-  // TODO: Typings for repositories is not working as expected, this needs
-  //  to be fixed.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return connection.model<T>(name, schema, collection);
 }

--- a/src/apps/backend/modules/otp/internal/store/otp-db.ts
+++ b/src/apps/backend/modules/otp/internal/store/otp-db.ts
@@ -15,7 +15,7 @@ export interface OtpDB {
   status: OtpStatus;
 }
 
-export const OtpDbSchema: Schema = new Schema<OtpDB>(
+export const OtpDbSchema = new Schema<OtpDB>(
   {
     active: {
       required: true,

--- a/src/apps/backend/modules/password-reset-token/internal/store/password-reset-token-db.ts
+++ b/src/apps/backend/modules/password-reset-token/internal/store/password-reset-token-db.ts
@@ -8,7 +8,7 @@ export interface PasswordResetTokenDB {
   isUsed: boolean;
 }
 
-export const passwordResetTokenDbSchema: Schema = new Schema<PasswordResetTokenDB>(
+export const passwordResetTokenDbSchema = new Schema<PasswordResetTokenDB>(
   {
     account: {
       ref: 'Account',

--- a/src/apps/backend/modules/task/internal/store/task-db.ts
+++ b/src/apps/backend/modules/task/internal/store/task-db.ts
@@ -8,7 +8,7 @@ export interface TaskDB {
   title: string;
 }
 
-export const TaskDbSchema: Schema = new Schema<TaskDB>(
+export const TaskDbSchema = new Schema<TaskDB>(
   {
     active: {
       type: Boolean,


### PR DESCRIPTION
## Description
Resolved a TypeScript lint error related to the unsafe assignment of a Mongoose schema to a generic repository function. The issue occurred because the schema was not strongly typed, causing a type mismatch in the ApplicationRepository function. Updated the ApplicationRepository function to enforce type safety by requiring a Schema<T> and ensured that the schema instances, like AccountDbSchema, are correctly typed as Schema<AccountDB>. This fixes the lint error and maintains type safety across the application.

## Database schema changes
- NA

## Tests
### Automated test cases added
- NA

### Manual test cases run
- Tested using the `lint` script.