### PR TITLE
fix: clean_on_pr_closed workflow not getting triggered incase if the PR consists merge conflicts

### DIFF
--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -6,8 +6,6 @@ on:
 
 jobs:
   clean:
-    # Only run for the organization's pr(s) to avoid the risk of exposing secrets to fork repos
-    if: github.repository_owner == 'jalantechnologies'
     uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v2.4
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   clean:
+    # Only run for the organization's pr(s) to avoid the risk of exposing secrets to fork repos
+    if: github.repository_owner == 'jalantechnologies'
     uses: jalantechnologies/github-ci/.github/workflows/clean.yml@v2.4
     concurrency:
       group: ci-preview-${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/clean_on_pr_closed.yml
+++ b/.github/workflows/clean_on_pr_closed.yml
@@ -1,8 +1,8 @@
 name: clean_on_pr_closed
 
 on:
-  pull_request:
-    types: [ closed ]
+  pull_request_target:
+    types: [closed]
 
 jobs:
   clean:


### PR DESCRIPTION
## Description
This PR introduces the fix for the issue [#54](https://github.com/orgs/jalantechnologies/projects/1/views/1?pane=issue&itemId=80103137), in which `clean_on_pr_closed` workflow is not getting triggered incase if the PR consists merge conflicts. Replaced `pull_request` event trigger with `pull_request_target` as fix for this problem.

Plase note:
- The pull_request_target event will not trigger if the workflow is just placed in the .github/workflows directory of the PR's head branch, but it must exist in the base branch. We should make sure the workflow exists in the base branch at the time the PR is opened. So moving forward this will work as expected but won't work for the existing PR's until their base branch have been edited and added as `main`.

## Database schema changes
- NA

## Tests
### Automated test cases added
- NA

### Manual test cases run
_For each manual test case, list the steps to test or reproduce the PR._
- Tested by closing a PR with merge conflicts

https://github.com/user-attachments/assets/b662c9c2-1d45-4c4c-9d3e-39df88ed4d28


