### PR TITLE
fix: 'gap-' not a Tailwind Class warning

### DIFF
--- a/src/apps/frontend/components/layouts/horizontal-stack-layout.tsx
+++ b/src/apps/frontend/components/layouts/horizontal-stack-layout.tsx
@@ -6,8 +6,11 @@ interface HorizontalStackLayoutProps {
 
 const HorizontalStackLayout: React.FC<
   PropsWithChildren<HorizontalStackLayoutProps>
-> = ({ children, gap = 0 }) => (
-  <div className={`gap-${gap} flex items-center`}>{children}</div>
-);
-
+> = ({ children, gap = 0 }) => {
+  const gapClass = gap ? `gap-${gap}` : '';
+  return (
+    <div className={`${gapClass} flex items-center`}>{children}</div>
+  )
+};
+  
 export default HorizontalStackLayout;

--- a/src/apps/frontend/components/layouts/vertical-stack-layout.tsx
+++ b/src/apps/frontend/components/layouts/vertical-stack-layout.tsx
@@ -6,8 +6,11 @@ interface VerticalStackLayoutProps {
 
 const VerticalStackLayout: React.FC<
   PropsWithChildren<VerticalStackLayoutProps>
-> = ({ children, gap = 0 }) => (
-  <div className={`gap-${gap} flex flex-col justify-center`}>{children}</div>
-);
+> = ({ children, gap = 0 }) => {
+  const gapClass = gap ? `gap-${gap}` : '';
+  return (
+    <div className={`${gapClass} flex flex-col justify-center`}>{children}</div>
+  )
+};
 
 export default VerticalStackLayout;


### PR DESCRIPTION
Fixed the warning (Classname 'gap-' is not a Tailwind CSS class!) thrown during linting
