### PR TITLE
chore:Add a link to Login/SignUp using OTP mode

### DIFF
--- a/src/apps/frontend/pages/authentication/login/login-form.tsx
+++ b/src/apps/frontend/pages/authentication/login/login-form.tsx
@@ -91,6 +91,12 @@ const LoginForm: React.FC<LoginFormProps> = ({ onError, onSuccess }) => {
             Sign Up
           </Link>
         </p>
+        <p className="self-center font-medium">
+          Login with{' '}
+          <Link to={routes.PHONE_LOGIN} className="text-primary">
+            OTP
+          </Link>
+        </p>
       </VerticalStackLayout>
     </form>
   );

--- a/src/apps/frontend/pages/authentication/login/login-form.tsx
+++ b/src/apps/frontend/pages/authentication/login/login-form.tsx
@@ -93,7 +93,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onError, onSuccess }) => {
         </p>
         <p className="self-center font-medium">
           Login with{' '}
-          <Link to={routes.PHONE_LOGIN} className="text-primary">
+          <Link className="text-primary" to={routes.PHONE_LOGIN}>
             OTP
           </Link>
         </p>

--- a/src/apps/frontend/pages/authentication/otp/otp-form.tsx
+++ b/src/apps/frontend/pages/authentication/otp/otp-form.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../components';
 import routes from '../../../constants/routes';
 import { AsyncError } from '../../../types';
-import { ButtonKind, ButtonType } from '../../../types/button';
+import { ButtonKind, ButtonSize, ButtonType } from '../../../types/button';
 
 import useOTPForm from './otp-form-hook';
 
@@ -89,8 +89,9 @@ const OTPForm: React.FC<OTPFormProps> = ({
 
         <Button
           type={ButtonType.SUBMIT}
-          isLoading={isVerifyOTPLoading}
           kind={ButtonKind.PRIMARY}
+          isLoading={isVerifyOTPLoading}
+          size={ButtonSize.LARGE}
         >
           Verify
         </Button>

--- a/src/apps/frontend/pages/authentication/otp/otp-form.tsx
+++ b/src/apps/frontend/pages/authentication/otp/otp-form.tsx
@@ -88,10 +88,10 @@ const OTPForm: React.FC<OTPFormProps> = ({
         </Flex>
 
         <Button
-          type={ButtonType.SUBMIT}
-          kind={ButtonKind.PRIMARY}
           isLoading={isVerifyOTPLoading}
+          kind={ButtonKind.PRIMARY}
           size={ButtonSize.LARGE}
+          type={ButtonType.SUBMIT}
         >
           Verify
         </Button>

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
@@ -92,10 +92,10 @@ const PhoneLoginForm: React.FC<PhoneLoginFormProps> = ({
             </div>
           </Flex>
           <Button
-            type={ButtonType.SUBMIT}
-            kind={ButtonKind.PRIMARY}
             isLoading={isSendOTPLoading}
+            kind={ButtonKind.PRIMARY}
             size={ButtonSize.LARGE}
+            type={ButtonType.SUBMIT}
           >
             Get OTP
           </Button>

--- a/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
+++ b/src/apps/frontend/pages/authentication/phone-login/phone-login-form.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../components';
 import COUNTRY_SELECT_OPTIONS from '../../../constants/countries';
 import { AsyncError } from '../../../types';
-import { ButtonKind, ButtonType } from '../../../types/button';
+import { ButtonKind, ButtonSize, ButtonType } from '../../../types/button';
 
 import usePhoneLoginForm from './phone-login-form.hook';
 
@@ -93,8 +93,9 @@ const PhoneLoginForm: React.FC<PhoneLoginFormProps> = ({
           </Flex>
           <Button
             type={ButtonType.SUBMIT}
-            isLoading={isSendOTPLoading}
             kind={ButtonKind.PRIMARY}
+            isLoading={isSendOTPLoading}
+            size={ButtonSize.LARGE}
           >
             Get OTP
           </Button>

--- a/src/apps/frontend/pages/authentication/signup/signup-form.tsx
+++ b/src/apps/frontend/pages/authentication/signup/signup-form.tsx
@@ -123,13 +123,13 @@ const SignupForm: React.FC<SignupFormProps> = ({ onError, onSuccess }) => {
         </Button>
         <p className="self-center font-medium">
           Already have an account?{' '}
-          <Link to={routes.LOGIN} className="text-primary">
+          <Link className="text-primary" to={routes.LOGIN}>
             Log in
           </Link>
         </p>
         <p className="self-center font-medium">
           Signup with{' '}
-          <Link to={routes.PHONE_LOGIN} className="text-primary">
+          <Link className="text-primary" to={routes.PHONE_LOGIN}>
             OTP
           </Link>
         </p>

--- a/src/apps/frontend/pages/authentication/signup/signup-form.tsx
+++ b/src/apps/frontend/pages/authentication/signup/signup-form.tsx
@@ -127,6 +127,12 @@ const SignupForm: React.FC<SignupFormProps> = ({ onError, onSuccess }) => {
             Log in
           </Link>
         </p>
+        <p className="self-center font-medium">
+          Signup with{' '}
+          <Link to={routes.PHONE_LOGIN} className="text-primary">
+            OTP
+          </Link>
+        </p>
       </VerticalStackLayout>
     </form>
   );


### PR DESCRIPTION
## Description
Resolves: [Issue #137](https://github.com/jalantechnologies/boilerplate-mern/issues/137)

Add a link to OTP page from Login and SignUp pages
Change styling of the buttons on the OTP pages




## Database schema changes
NA

## Tests
### Manual test cases run
### **1)Tested the changes made to the UI on Local Host**
(Attaching images for the changes )

added the link to otp page on the login page
<img width="1440" alt="login" src="https://github.com/user-attachments/assets/a77dccc1-be87-4de1-b996-8f2b67f3c9bf" />

added the link to otp page on the signup page
<img width="1440" alt="signup" src="https://github.com/user-attachments/assets/df18297f-7c45-49bb-97f2-9114838aefb0" />

changed the button styles on the otp pages
<img width="1440" alt="otp_verify" src="https://github.com/user-attachments/assets/9ff1ed3a-e7e8-4366-8f05-797669b91e00" />
<img width="1440" alt="otp_details" src="https://github.com/user-attachments/assets/94ae0bd9-b4fa-45c5-abe2-c663d219deb3" />


### **2)Tested the changes made to the UI on the Preview App**
(Attaching images for the changes )

added the link to otp page on the login page
<img width="1440" alt="login_img_dep" src="https://github.com/user-attachments/assets/646bab96-beed-459a-a6fc-f1f4a7295c46" />

added the link to otp page on the signup page
<img width="1440" alt="signup_img_dep" src="https://github.com/user-attachments/assets/9fea436c-b14c-4215-8a47-52f59e27d493" />

changed the button styles on the otp pages
<img width="1440" alt="otp_img1_dep" src="https://github.com/user-attachments/assets/b47df239-3513-4fcc-9fd4-302d64daaf49" />
<img width="1440" alt="otp_img2_dep" src="https://github.com/user-attachments/assets/14b95b91-ce29-48d0-81a7-365928d29475" />
