### PR TITLE
fix: docker dev build

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
     environment:
       NODE_ENV: 'development'
       NODE_APP_INSTANCE: 'docker'
-    command: 'npm run serve'
+    command: /bin/sh -c "npm install && npm run serve"
     depends_on:
       - db
     ports:


### PR DESCRIPTION
## Description

Resolves #203

## Tests

## Manual Test Cases

Previously the docker build would exit as under:

![image](https://github.com/user-attachments/assets/e72caf1a-d09f-4a54-8fb8-da0c1554765c)

After applying this fix, I tried running the docker build command, and it worked without any issues
 
![image](https://github.com/user-attachments/assets/e899673e-f128-4a2d-be60-b6ebb3370dd8)

I've confirmed the same with @saisudan2003, this issue was specific to macOS. 