### PR TITLE
Implementing error boundaries with Datadog support

### DIFF
--- a/src/apps/backend/app.ts
+++ b/src/apps/backend/app.ts
@@ -32,6 +32,8 @@ export default class App {
 
   public static async startServer(): Promise<Server> {
     this.app = express();
+
+    this.app.use(express.json());
     this.app.use(App.getRequestLogger());
 
     const restAPIServer = this.createRESTApiServer();
@@ -100,6 +102,12 @@ export default class App {
         })
       );
     }
+
+    app.post('/client_logs', (request, response) => {
+      console.log('Hello');
+      console.log(request.body);
+      response.status(200).send({ message: 'Logs Sent' });
+    });
 
     this.getAPIMicroservices().forEach((server) => {
       app.use('/', server.serverInstance.server);

--- a/src/apps/backend/app.ts
+++ b/src/apps/backend/app.ts
@@ -2,7 +2,7 @@ import { Server } from 'http';
 import * as path from 'path';
 
 import cors from 'cors';
-import express, { Application } from 'express';
+import express, { Application, Request, Response } from 'express';
 import expressWinston from 'express-winston';
 
 import { AccessTokenServer } from './modules/access-token';
@@ -21,6 +21,12 @@ import { TaskServer } from './modules/task';
 interface APIMicroserviceService {
   rootFolderPath: string;
   serverInstance: ApplicationServer;
+}
+
+interface ClientLog {
+  errorMessage: string;
+  errorName: string;
+  errorInfo: string;
 }
 
 const isDevEnv = process.env.NODE_ENV === 'development';
@@ -103,11 +109,14 @@ export default class App {
       );
     }
 
-    app.post('/client_logs', (request, response) => {
-      console.log('Hello');
-      console.log(request.body);
-      response.status(200).send({ message: 'Logs Sent' });
-    });
+    app.post(
+      '/client_logs',
+      (errorData: Request<unknown, unknown, ClientLog>, response: Response) => {
+        const { errorMessage, errorName, errorInfo } = errorData.body;
+        Logger.error(errorMessage, [errorName, errorInfo]);
+        response.status(200).send({ message: 'Logs Sent' });
+      }
+    );
 
     this.getAPIMicroservices().forEach((server) => {
       app.use('/', server.serverInstance.server);

--- a/src/apps/frontend/components/error/error-boundary.tsx
+++ b/src/apps/frontend/components/error/error-boundary.tsx
@@ -33,7 +33,7 @@ class ErrorBoundary extends Component<Props, State> {
       'error-info': errorInfo.componentStack,
     };
     try {
-      await axios.post('http://127.0.0.1:8080/client_logs', this.errorData);
+      await axios.post('http://localhost:8080/api/client_logs', this.errorData);
     } catch (err) {
       console.error('Error logging client logs:', err);
     }

--- a/src/apps/frontend/components/error/error-boundary.tsx
+++ b/src/apps/frontend/components/error/error-boundary.tsx
@@ -1,0 +1,51 @@
+import axios from 'axios';
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+import { JsonObject } from '../../types/common-types';
+
+interface Props {
+  children?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+  };
+
+  errorData: JsonObject & {
+    'error-info': string;
+    'error-message': string;
+    'error-name': string;
+  };
+
+  public static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  public async componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.errorData = {
+      'error-name': error.name,
+      'error-message': error.message,
+      'error-info': errorInfo.componentStack,
+    };
+    try {
+      await axios.post('http://127.0.0.1:8080/client_logs', this.errorData);
+    } catch (err) {
+      console.error('Error logging client logs:', err);
+    }
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return <div>Sorry.. there was an error</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/apps/frontend/components/error/error-boundary.tsx
+++ b/src/apps/frontend/components/error/error-boundary.tsx
@@ -17,9 +17,9 @@ class ErrorBoundary extends Component<Props, State> {
   };
 
   errorData: JsonObject & {
-    'error-info': string;
-    'error-message': string;
-    'error-name': string;
+    errorInfo: string;
+    errorMessage: string;
+    errorName: string;
   };
 
   public static getDerivedStateFromError(): State {
@@ -28,9 +28,9 @@ class ErrorBoundary extends Component<Props, State> {
 
   public async componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.errorData = {
-      'error-name': error.name,
-      'error-message': error.message,
-      'error-info': errorInfo.componentStack,
+      errorName: error.name,
+      errorMessage: error.message,
+      errorInfo: errorInfo.componentStack,
     };
     try {
       await axios.post('http://localhost:8080/api/client_logs', this.errorData);


### PR DESCRIPTION
## Description
Adding error boundaries which directly log errors to Datadog via sending the logs to a route on backend, and then using the logger to push logs to datadog

## Manual Testing : 
- 
