### PR TITLE
fix: prevent duplicate SonarQube comments on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,27 @@ jobs:
           path: platform
           ref: ${{ steps.ci_version.outputs.version }}
 
+      - name: Delete old SonarQube comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            for (const comment of comments.data) {
+              if (comment.user.login.includes('sonarqube')) {
+                console.log(`Deleting comment ${comment.id} from ${comment.user.login}`);
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id,
+                });
+              }
+            }
+
       - name: Run SonarQube analysis
         uses: ./platform/.github/actions/analyze
         with:


### PR DESCRIPTION
## Summary
- Fixes duplicate SonarQube comments appearing on PRs with multiple commits
- Adds cleanup step to delete old SonarQube bot comments before posting new analysis results

## Problem
Currently, SonarQube creates a new comment with each push/commit instead of updating the existing one. This causes:
- Multiple SonarQube comments accumulating on PRs (e.g., PR #238 had 9 comments, PR #240 had 2)
- Notification noise for reviewers
- Cluttered PR timeline

## Root Cause
The `sonarsource/sonarqube-scan-action` was supposed to delete old comments but this wasn't working consistently. Each new analysis created a new comment instead of replacing the previous one.

## Solution
Added a `Delete old SonarQube comments` step before running the analysis that:
1. Lists all comments on the PR
2. Identifies comments from SonarQube bots (any user login containing "sonarqube")
3. Deletes those comments
4. Allows the new analysis to post fresh results

This mirrors the pattern used by the code coverage step with the sticky-pull-request-comment action.

## Test Plan
- [x] Verify CI workflow syntax is valid
- [ ] Verify old SonarQube comments are deleted on first push
- [ ] Verify new SonarQube comment is posted successfully
- [ ] Push another commit and verify only one comment remains
- [ ] Check that the cleanup doesn't affect other bot comments (coverage, deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)