### PR TITLE
feat: move picking variables from environment to files

### DIFF
--- a/src/apps/backend/modules/config/config-service.ts
+++ b/src/apps/backend/modules/config/config-service.ts
@@ -1,9 +1,15 @@
 import { ConfigMissingError } from 'backend/modules/config';
+import SecretFileLoader from 'backend/modules/config/internals/secret-file-loader';
 import config from 'config';
 import _ from 'lodash';
 
 export default class ConfigService {
   static getValue<T = unknown>(key: string): T {
+    const secretOverride = SecretFileLoader.getValue<T>(key);
+    if (!_.isNil(secretOverride)) {
+      return secretOverride;
+    }
+
     const value = config.get<T>(key);
 
     if (_.isNil(value)) {

--- a/src/apps/backend/modules/config/internals/secret-file-loader.ts
+++ b/src/apps/backend/modules/config/internals/secret-file-loader.ts
@@ -1,0 +1,107 @@
+import fs from 'fs';
+import path from 'path';
+
+import yaml from 'js-yaml';
+import _ from 'lodash';
+
+type SecretFileMap = Record<string, unknown>;
+
+export default class SecretFileLoader {
+  private static readonly defaultConfigPath = path.resolve(
+    process.cwd(),
+    'config/custom-environment-variables.yml'
+  );
+
+  private static readonly fallbackSecretBasePath = '/opt/app/secrets';
+
+  private static fileMap: SecretFileMap | null = null;
+
+  private static hasLoaded = false;
+
+  static getValue<T = string>(key: string): T | undefined {
+    this.loadConfig();
+
+    if (_.isNil(this.fileMap)) {
+      return undefined;
+    }
+
+    const secretPath = _.get(this.fileMap, key);
+
+    if (!secretPath || !_.isString(secretPath)) {
+      return undefined;
+    }
+
+    return this.readSecret(secretPath) as T;
+  }
+
+  static reset(): void {
+    this.fileMap = null;
+    this.hasLoaded = false;
+  }
+
+  private static getConfigPaths(): string[] {
+    const envValue = process.env.CONFIG_SECRET_FILES_PATHS;
+
+    if (_.isNil(envValue)) {
+      return [this.defaultConfigPath];
+    }
+
+    return envValue
+      .split(path.delimiter)
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map((value) =>
+        path.isAbsolute(value) ? value : path.resolve(process.cwd(), value)
+      );
+  }
+
+  private static getSecretBasePath(): string {
+    return process.env.CONFIG_SECRET_BASE_PATH ?? this.fallbackSecretBasePath;
+  }
+
+  private static loadConfig(): void {
+    if (this.hasLoaded) {
+      return;
+    }
+
+    this.fileMap = {};
+
+    this.getConfigPaths()
+      .filter((configPath) => fs.existsSync(configPath))
+      .forEach((configPath) => {
+        const fileContents = fs.readFileSync(configPath, 'utf8');
+
+        if (_.isEmpty(fileContents)) {
+          return;
+        }
+
+        const parsed = yaml.load(fileContents) as SecretFileMap | undefined;
+
+        if (!_.isPlainObject(parsed)) {
+          return;
+        }
+
+        this.fileMap = _.merge(this.fileMap, parsed);
+      });
+
+    this.hasLoaded = true;
+  }
+
+  private static resolveSecretPath(secretPath: string): string {
+    if (path.isAbsolute(secretPath)) {
+      return secretPath;
+    }
+
+    return path.resolve(this.getSecretBasePath(), secretPath);
+  }
+
+  private static readSecret(secretPath: string): string | undefined {
+    const absolutePath = this.resolveSecretPath(secretPath);
+
+    if (!fs.existsSync(absolutePath)) {
+      return undefined;
+    }
+
+    return fs.readFileSync(absolutePath, 'utf8').trim();
+  }
+}

--- a/test/spec/config/config.spec.ts
+++ b/test/spec/config/config.spec.ts
@@ -1,5 +1,19 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
 import { ConfigService } from 'backend/modules/config';
+import SecretFileLoader from 'backend/modules/config/internals/secret-file-loader';
 import { assert } from 'chai';
+
+const restoreEnvVar = (key: string, value: string | undefined): void => {
+  if (typeof value === 'undefined') {
+    delete process.env[key];
+    return;
+  }
+
+  process.env[key] = value;
+};
 
 describe('ConfigService', () => {
   describe('getValue', () => {
@@ -31,6 +45,46 @@ describe('ConfigService', () => {
         () => ConfigService.getValue(missingKey),
         `Configuration property "${missingKey}" is not defined`
       );
+    });
+
+    it('should source values from secret files when configured', () => {
+      const secretFileName = 'test_secret_value';
+      const initialSecretFilesPath = process.env.CONFIG_SECRET_FILES_PATHS;
+      const initialSecretBasePath = process.env.CONFIG_SECRET_BASE_PATH;
+      let tempDir: string | undefined;
+
+      try {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-secret-'));
+        const secretBasePath = path.join(tempDir, 'secrets');
+        fs.mkdirSync(secretBasePath, { recursive: true });
+        fs.writeFileSync(
+          path.join(secretBasePath, secretFileName),
+          'value-from-secret-file'
+        );
+
+        const customEnvFilePath = path.join(tempDir, 'custom-env.yml');
+        fs.writeFileSync(
+          customEnvFilePath,
+          `test:\n  stringTestKey: ${secretFileName}\n`
+        );
+
+        process.env.CONFIG_SECRET_FILES_PATHS = customEnvFilePath;
+        process.env.CONFIG_SECRET_BASE_PATH = secretBasePath;
+
+        SecretFileLoader.reset();
+
+        const value = ConfigService.getValue<string>('test.stringTestKey');
+
+        assert.equal(value, 'value-from-secret-file');
+      } finally {
+        SecretFileLoader.reset();
+        restoreEnvVar('CONFIG_SECRET_FILES_PATHS', initialSecretFilesPath);
+        restoreEnvVar('CONFIG_SECRET_BASE_PATH', initialSecretBasePath);
+
+        if (tempDir && fs.existsSync(tempDir)) {
+          fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+      }
     });
   });
 


### PR DESCRIPTION
## Description
This PR pertains to [PR](https://github.com/jalantechnologies/node-react-template/pull/259) where we are addressing how the config variables are being picked from files rather than environment variables

## Changes Made 
- I have added  `src/apps/backend/modules/config/internals/secret-file-loader.ts` file that checks for secret files stored at `/opt/apps/secrets`
- I have added a test case that test for files in secrets in `config.spec.ts`

