### PR TITLE
fix: upgrade cd version for production and permanent preview

### DIFF
--- a/.github/workflows/permanent_preview.yml
+++ b/.github/workflows/permanent_preview.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           repository: jalantechnologies/github-ci
           path: platform
-          ref: 1e27a09243327a4ed01d42a9bc54965436ac0ba4
+          ref: 4083bbf5abc5a3e79d85a9f551c75919aaad6dfb
 
       - name: Build Docker image
         id: build

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           repository: jalantechnologies/github-ci
           path: platform
-          ref: 1e27a09243327a4ed01d42a9bc54965436ac0ba4
+          ref: 4083bbf5abc5a3e79d85a9f551c75919aaad6dfb
 
       - name: Build Docker image
         id: build


### PR DESCRIPTION
## Description
In this PR we are upgrading github-ci version that accepts image_name , image_tag and image_digest as a parameter