### PR TITLE
fix : upgraded the jsw dependencies to resolve scan error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13548,12 +13548,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
   "overrides": {
     "braces": "3.0.3",
     "minimist": "^1.2.8",
-    "nconf": "0.11.4"
+    "nconf": "0.11.4",
+    "jws": "3.2.3"
   }
 }


### PR DESCRIPTION
**Why these changes require**
Trivy ci scan job is failing due to outdated version of the dependencies jsw. Due to which which ci check is failing

**What changes done**
Upgraded the dependencies version to require version which made the ci scan job to pass which in turn pass ci job

**Manual testing done**
**1) without updgarding the version of dependecies**
<img width="1885" height="746" alt="image" src="https://github.com/user-attachments/assets/8a73c8c2-0a92-4d5c-a459-63d3ab9bcf7d" />

2)After updgrading the version of dependecies
<img width="1919" height="764" alt="image" src="https://github.com/user-attachments/assets/0b6dac8a-cbde-4105-9648-e9ca29e1628a" />

Loom video : https://www.loom.com/share/0ff80cf96a78479f83b84f6d86cc4746

