### PR TITLE
fix: generating hash using pr number instead of branch name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     concurrency:
-      group: cd-preview-${{ github.event.pull_request.head.ref }}
+      group: cd-preview-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
       - name: Checkout app
@@ -33,8 +33,8 @@ jobs:
       - name: Extract branch name
         id: extract_branch
         run: |
-          BRANCH_NAME=$(echo ${{ github.event.pull_request.head.ref }} | sed -e 's/^refs\/heads\///g')
-          BRANCH_HASH=$(sha1sum < <(printf '%s' $BRANCH_NAME) | cut -c -15)
+          PREVIEW_KEY="pr-${{ github.event.pull_request.number }}"
+          BRANCH_HASH=$(sha1sum < <(printf '%s' "$PREVIEW_KEY") | cut -c -15)
           echo "branch_hash=$(echo $BRANCH_HASH)" >> $GITHUB_OUTPUT
 
       - name: Build Docker image
@@ -55,7 +55,7 @@ jobs:
           app_name: node-react-template
           app_env: preview
           app_hostname: '{1}.preview.platform.bettrhq.com'
-          branch: ${{ github.event.pull_request.head.ref }}
+          branch: pr-${{ github.event.pull_request.number }}
           deploy_id: ${{ github.run_number }}
           deploy_root: app/lib/kube
           deploy_labels: gh/pr=${{ github.event.number }}

--- a/.github/workflows/cleanup_pr.yml
+++ b/.github/workflows/cleanup_pr.yml
@@ -14,12 +14,12 @@ jobs:
   clean:
     uses: jalantechnologies/github-ci/.github/workflows/clean.yml@1e27a09243327a4ed01d42a9bc54965436ac0ba4
     concurrency:
-      group: ci-preview-${{ github.event.pull_request.head.ref }}
+      group: ci-preview-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     with:
       app_name: node-react-template
       app_env: preview
-      branch: ${{ github.event.pull_request.head.ref }}
+      branch: pr-${{ github.event.pull_request.number }}
       docker_registry: ${{ vars.DOCKER_REGISTRY }}
       docker_username: ${{ vars.DOCKER_USERNAME }}
       do_cluster_id: ${{ vars.DO_CLUSTER_ID }}


### PR DESCRIPTION
**Why these changes were needed**
Previously, both the deploy (cd.yml) and cleanup (clean.yml) workflows generated the preview hash from the branch name (head_ref).Because the hash was derived directly from the branch name, different PRs using the same branch name ended up generating the same hash value.

**This caused a critical issue:**

- Multiple PRs (from the same repository or from forked repositories) could use the same branch name (for example, main)
- Since the hash was generated from the branch name, these PRs produced the same preview hash
- As a result, different PRs shared the same preview environment
- When one PR was closed, its cleanup workflow deleted Kubernetes resources (deployments, services, ingress) belonging to another PR or the permanent preview
- Workflow concurrency was also branch-based, so PRs sharing a branch name could cancel or interfere with each other’s preview runs

**What changes were done**

- Switched preview hash generation from branch-based to PR-number–based.The preview hash is now generated from pr-<PR_NUMBER> instead of the branch name.This ensures that each PR always generates a unique hash

- Aligned deploy and cleanup workflows to use the same PR-based hash.cd.yml deploys preview environments using branch: pr-<PR_NUMBER>
- clean.yml cleans up resources using the same branch: pr-<PR_NUMBER>.This guarantees that a cleanup workflow can only delete resources created by the same PR


**Manual testing** 
**1)When hash was calculated based on branch name  then two pr having same branch name was generating same hash number**
**Permanent preview hash number**
<img width="743" height="236" alt="image" src="https://github.com/user-attachments/assets/391f1d6c-ec2b-4c18-87c9-b8807f18a5b5" />

**Forked repo PR raised from main branch hash** 
<img width="579" height="159" alt="image" src="https://github.com/user-attachments/assets/27522d11-f02b-4167-92a3-45327fa91bec" />

**2)After implementing hash using pr number** 
**Forked repo PR raised from main branch** 
<img width="742" height="286" alt="image" src="https://github.com/user-attachments/assets/14d63e0a-5101-44fa-97e1-d9c2dc3bafd4" />

**Permanent preview hash number**
<img width="743" height="236" alt="image" src="https://github.com/user-attachments/assets/391f1d6c-ec2b-4c18-87c9-b8807f18a5b5" />



Loom video : https://www.loom.com/share/227fee5f7fc241a997bb75bb0ba10090

