### PR TITLE
fix: fix: freezing trivy database to prevent regular dep update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
+      - name: Cache Trivy DB
+        id: cache-trivy
+        uses: actions/cache@v4
+        with:
+          path: .trivy
+          key: trivy-db-v1
+
+      - name: Download Trivy DB
+        if: steps.cache-trivy.outputs.cache-hit != 'true'
+        uses: aquasecurity/trivy-action@0.33.0
+        with:
+          scan-type: 'filesystem'
+          scan-ref: '.'
+          cache-dir: .trivy
+          exit-code: 0
+
       - name: Extract branch name
         id: extract_branch
         run: |
@@ -120,6 +136,8 @@ jobs:
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
           trivyignores: ".trivyignore"
+          cache-dir: .trivy
+          skip-db-update: true
           exit-code: 1
       
       - name: Comment PR with audit results
@@ -167,6 +185,8 @@ jobs:
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
           trivyignores: ".trivyignore"
+          cache-dir: .trivy
+          skip-db-update: true
           exit-code: 1
 
       - name: Comment PR with audit results
@@ -213,6 +233,8 @@ jobs:
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
           trivyignores: ".trivyignore"
+          cache-dir: .trivy
+          skip-db-update: true
           exit-code: 1
           
       - name: Comment PR with audit results


### PR DESCRIPTION
**Why these changes require**

Previously, the CI pipeline was fetching the latest Trivy vulnerability database on every run. This caused the following issues:

- Non-deterministic failures: The pipeline would fail randomly even without any code changes if the upstream Trivy database added a new CVE definition.

- Broken builds: The pipeline was frequently entering a broken state due to these external updates, blocking development and merging.

**What changes done**

We have implemented a deterministic caching strategy for the Trivy database:

- Frozen DB Snapshot: configured the scan job to cache the Trivy database using a specific version key (trivy-db-v1).

- Disabled Auto-Updates: The scans now run with --skip-db-update and point to this cached directory (.trivy).

- Controlled Updates: The vulnerability database will now only update when we explicitly bump the cache key version in the workflow file.

**Manual testing** 
1)Pipeline failing randomly without code changes
<img width="1212" height="690" alt="image" src="https://github.com/user-attachments/assets/dca3312c-2521-4459-a25d-2a1401887f89" />


Loom video : https://www.loom.com/share/491d4c4670854614b6c8c2e0dfae88d5