### PR TITLE
fix: prevent Trivy scan comments when scans pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY package*.json ./
 RUN npm ci && npm cache clean --force
 
 # Production stage (minimal)
-FROM node:16.20.0-bullseye-slim
+FROM node:22.13.1-bookworm-slim
 WORKDIR /app
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     libnss3 libxss1 libxtst6 && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description
In this PR we are fixing the issue described in [285](https://github.com/jalantechnologies/node-react-template/issues/285). Here we have added a step to check for vulnerabilities even if they are added to trivyignore and exit with code 1 it shouldnt comment as below

Video Walkthrough: https://www.loom.com/share/03fbf1ac3a4a4574a7c72883adc585ff

<img width="970" height="315" alt="Image" src="https://github.com/user-attachments/assets/0e03205a-6fdd-43ec-94f8-de1eab0c7f40" />


## Changes

We have added additional step of checking report file like below
```
- name: Check if report contains any real vulnerabilities
        id: vuln_check
        run: |
          # Count how many vulnerabilities are listed in the markdown
          COUNT=$(grep -c "CVE-" trivy-docker-report.md || true)
          echo "vuln_count=$COUNT" >> $GITHUB_OUTPUT
```

- Added a vulnerability check to the Trivy report.

- New step counts CVE entries in trivy-docker-report.md and outputs vuln_count.

- PR comment now only posts when there are real vulnerabilities (vuln_count != 0) and the report exists.

- If no CVEs are found or the report is empty, no comment is posted.

## Tests
### Manual test cases run
test 1: confirm no message is generated for passed PRs 
-  created a PR for the trivy scan fix and confirmed in the new PR no scan report is generated in comments when the test pass
-  this confirms that when the ci tests pass trivy would not comment the results in the PRs 
<img width="1889" height="868" alt="image" src="https://github.com/user-attachments/assets/642e4889-ce50-47d3-84c7-d20d8a43bad4" />

Test Case 2: Confirm message is generated when vulnerabilities are found
- Used older Node.js base image (node:16.20.0-bullseye-slim) with known vulnerabilities in the PR
- Triggered CI pipeline and observed Trivy scan behavior when actual CVEs are detected
- This confirms that when real vulnerabilities exist, trivy comments the results with specific CVE details in the PRs
<img width="1918" height="962" alt="image" src="https://github.com/user-attachments/assets/2dd45a69-9fc5-484f-8899-de910b72cb75" />

